### PR TITLE
Revert back back to jammy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.10-noble as build
+FROM swift:5.10-jammy as build
 
 # Install OS updates and, if needed, sqlite3
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
@@ -53,7 +53,7 @@ RUN [ -d /build/Temp ] && { mv /build/Temp ./Temp && chmod -R a+rw ./Temp; } || 
 # ================================
 # Run image
 # ================================
-FROM ubuntu:noble
+FROM ubuntu:jammy
 
 # Make sure all system packages are up to date, and install only essential packages.
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \


### PR DESCRIPTION
Need to revert back since during the Docker build on Linux there is an error:

```
#18 643.0 error: compile command failed due to signal 6 (use -v to see invocation)
#18 643.0 swift-frontend: /home/build-user/llvm-project/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp:679: void llvm::DwarfExpression::addFragmentOffset(const DIExpression *): Assertion `FragmentOffset >= OffsetInBits && "overlapping or duplicate fragments"' failed.
#18 643.0 Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
#18 643.0 Stack dump:
#18 643.0 0.	Running pass 'Function Pass Manager' on module '/build/.build/x86_64-unknown-linux-gnu/release/VernissageServer.build/Application+Configure.swift.o'.
#18 643.0 1.	Running pass 'X86 Assembly Printer' on function '@"$s16VernissageServer19LocalizablesServiceC3get2on4code6locale9variablesSS9FluentKit8Database_p_S2SSDyS2SGSgtYaKFTf4nnnnd_nTY2_"'
#18 643.0 Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
```

Similar issue opened here: https://github.com/swiftlang/swift/issues/68263