### PR TITLE
Fix signature validation

### DIFF
--- a/Sources/VernissageServer/Errors/ActivityPubError.swift
+++ b/Sources/VernissageServer/Errors/ActivityPubError.swift
@@ -17,7 +17,6 @@ enum ActivityPubError: Error {
     case missingActivityPubProfileInKeyId(String)
     case missingSignedHeader(String)
     case signatureIsNotValid
-    case singleActorIsSupportedInSigning
     case userNotExistsInDatabase(String)
     case privateKeyNotExists(String)
     case publicKeyNotExists(String)
@@ -56,7 +55,6 @@ extension ActivityPubError: LocalizedTerminateError {
         case .missingActivityPubProfileInKeyId(let keyIdValue): return "Cannot find actor profile in keyId \(keyIdValue)."
         case .missingSignedHeader(let headerName): return "Cannot find header '\(headerName)' used to create signature in ActivityPub request."
         case .signatureIsNotValid: return "ActivityPub request signature is not valid."
-        case .singleActorIsSupportedInSigning: return "Single actor is supported in ActivityPub request signing."
         case .userNotExistsInDatabase(let activityPubProfile): return "User '\(activityPubProfile)' cannot be found in the local database."
         case .privateKeyNotExists(let activityPubProfile): return "Private key not found in local database for user: '\(activityPubProfile)'."
         case .publicKeyNotExists(let activityPubProfile): return "Public key not found in local database for user: '\(activityPubProfile)'."
@@ -95,7 +93,6 @@ extension ActivityPubError: LocalizedTerminateError {
         case .missingActivityPubProfileInKeyId: return "missingActivityPubProfileInKeyId"
         case .missingSignedHeader: return "missingSignedHeader"
         case .signatureIsNotValid: return "signatureIsNotValid"
-        case .singleActorIsSupportedInSigning: return "singleActorIsSupportedInSigning"
         case .userNotExistsInDatabase: return "userNotExistsInDatabase"
         case .privateKeyNotExists: return "privateKeyNotExists"
         case .publicKeyNotExists: return "publicKeyNotExists"

--- a/Sources/VernissageServer/Errors/ActivityPubError.swift
+++ b/Sources/VernissageServer/Errors/ActivityPubError.swift
@@ -13,6 +13,8 @@ enum ActivityPubError: Error {
     case missingSignatureHeader
     case missingSignedHeadersList
     case missingSignatureInHeader
+    case missingKeyIdInHeader
+    case missingActivityPubProfileInKeyId(String)
     case missingSignedHeader(String)
     case signatureIsNotValid
     case singleActorIsSupportedInSigning
@@ -50,6 +52,8 @@ extension ActivityPubError: LocalizedTerminateError {
         case .missingSignatureHeader: return "ActivityPub request 'Signature' header is missing."
         case .missingSignedHeadersList: return "Cannot read list of signed headers from ActivityPub request."
         case .missingSignatureInHeader: return "Cannot read signature in header in ActivityPub request."
+        case .missingKeyIdInHeader: return "Cannot read keyId from signature header in ActivityPub request."
+        case .missingActivityPubProfileInKeyId(let keyIdValue): return "Cannot find actor profile in keyId \(keyIdValue)."
         case .missingSignedHeader(let headerName): return "Cannot find header '\(headerName)' used to create signature in ActivityPub request."
         case .signatureIsNotValid: return "ActivityPub request signature is not valid."
         case .singleActorIsSupportedInSigning: return "Single actor is supported in ActivityPub request signing."
@@ -87,6 +91,8 @@ extension ActivityPubError: LocalizedTerminateError {
         case .missingSignatureHeader: return "missingSignatureHeader"
         case .missingSignedHeadersList: return "missingSignedHeadersList"
         case .missingSignatureInHeader: return "missingSignatureInHeader"
+        case .missingKeyIdInHeader: return "missingKeyIdInHeader"
+        case .missingActivityPubProfileInKeyId: return "missingActivityPubProfileInKeyId"
         case .missingSignedHeader: return "missingSignedHeader"
         case .signatureIsNotValid: return "signatureIsNotValid"
         case .singleActorIsSupportedInSigning: return "singleActorIsSupportedInSigning"

--- a/Sources/VernissageServer/Services/ActivityPubSignatureService.swift
+++ b/Sources/VernissageServer/Services/ActivityPubSignatureService.swift
@@ -42,12 +42,20 @@ final class ActivityPubSignatureService: ActivityPubSignatureServiceType {
         let cryptoService = context.application.services.cryptoService
         let activityPubService = context.application.services.activityPubService
         
-        // Get actor profile URL from activity.
-        let actorId = try self.getSignatureActor(activityPubRequest: activityPubRequest)
+        // Get actor profile URL from signature.
+        let signatureActorId = try self.getSignatureActor(activityPubRequest: activityPubRequest)
+        
+        // Get actor profile URL from payload.
+        let payloadActorId = try self.getPayloadActor(activityPubRequest: activityPubRequest)
         
         // Check if the actor's domain is blocked by the instance.
-        if try await activityPubService.isDomainBlockedByInstance(on: context.application, actorId: actorId) {
-            throw ActivityPubError.domainIsBlockedByInstance(actorId)
+        if try await activityPubService.isDomainBlockedByInstance(on: context.application, actorId: signatureActorId) {
+            throw ActivityPubError.domainIsBlockedByInstance(signatureActorId)
+        }
+        
+        // Check if the actor's domain is blocked by the instance.
+        if let payloadActorId,  try await activityPubService.isDomainBlockedByInstance(on: context.application, actorId: payloadActorId) {
+            throw ActivityPubError.domainIsBlockedByInstance(payloadActorId)
         }
         
         // Check if request is not old one.
@@ -59,15 +67,23 @@ final class ActivityPubSignatureService: ActivityPubSignatureServiceType {
         // Get signature from header (decoded base64 as Data).
         let signatureData = try self.getSignatureData(activityPubRequest: activityPubRequest)
                 
-        // Download profile from remote server.
-        guard let user = try await searchService.downloadRemoteUser(activityPubProfile: actorId, on: context) else {
-            throw ActivityPubError.userNotExistsInDatabase(actorId)
+        // Download signed profile from remote server.
+        guard let signedUser = try await searchService.downloadRemoteUser(activityPubProfile: signatureActorId, on: context) else {
+            throw ActivityPubError.userNotExistsInDatabase(signatureActorId)
         }
         
-        guard let publicKey = user.publicKey else {
-            throw ActivityPubError.publicKeyNotExists(actorId)
+        guard let publicKey = signedUser.publicKey else {
+            throw ActivityPubError.publicKeyNotExists(signatureActorId)
         }
-                
+        
+        // When signature and payload actors are different we have to also download actor from payload.
+        if let payloadActorId, signatureActorId != payloadActorId {
+            // Download payload profile from remote server.
+            guard let _ = try await searchService.downloadRemoteUser(activityPubProfile: payloadActorId, on: context) else {
+                throw ActivityPubError.userNotExistsInDatabase(payloadActorId)
+            }
+        }
+        
         // Verify signature with actor's public key.
         let isValid = try cryptoService.verifySignature(publicKeyPem: publicKey, signatureData: signatureData, digest: generatedSignatureData)
         if !isValid {
@@ -202,6 +218,11 @@ final class ActivityPubSignatureService: ActivityPubSignatureServiceType {
         }
 
         return String(activityPubProfile)
+    }
+    
+    private func getPayloadActor(activityPubRequest: ActivityPubRequestDto) throws -> String? {
+        let actorIds = activityPubRequest.activity.actor.actorIds()
+        return actorIds.first
     }
     
     private func verifyTimeWindow(activityPubRequest: ActivityPubRequestDto) throws {


### PR DESCRIPTION
I've used wrong actor public key to check te signature validation. I always used actor from the payload instead of actor from the `signature` HTTP header.