### PR TITLE
Revert back SwiftGD version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4e10f67e216698c464ad602230954eba8328417039bec85f0d8722e5480560ff",
+  "originHash" : "87c2a2dede10840b0a6cf0836c7e22bc172c0b2fc744a7c0edc8d2c49d02394e",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -490,10 +490,9 @@
     {
       "identity" : "swiftgd",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mczachurski/SwiftGD.git",
+      "location" : "https://github.com/twostraws/SwiftGD.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "69e3d1d2ff5da8b7d3c21c3688d6c585055a9ed7"
+        "revision" : "7b63390bc7faa998e293f2f5e9f929bd3dd23759"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -54,8 +54,7 @@ let package = Package(
         .package(url: "https://github.com/ordo-one/package-frostflake.git", from: "5.0.0"),
                 
         // 🖼️ Simple Swift wrapper for libgd, allowing for basic graphic rendering on server-side Swift where Core Graphics is not available.
-        // .package(url: "https://github.com/twostraws/SwiftGD.git", branch: "main"),
-        .package(url: "https://github.com/mczachurski/SwiftGD.git", branch: "main"),
+        .package(url: "https://github.com/twostraws/SwiftGD.git", revision: "7b63390bc7faa998e293f2f5e9f929bd3dd23759"),
         
         // ✍️ Fast and flexible Markdown parser written in Swift.
         .package(url: "https://github.com/johnsundell/ink.git", from: "0.6.0"),


### PR DESCRIPTION
Seems like `gdImageCreateFromAvifPtr` is not visible in Linux?


```
#18 94.04 /build/.build/checkouts/SwiftGD/Sources/SwiftGD/Format.swift:225:88: error: cannot find 'gdImageCreateFromAvifPtr' in scope
#18 94.04      fileprivate let importFunction: (Int32, UnsafeMutableRawPointer) -> gdImagePtr? = gdImageCreateFromAvifPtr
#18 94.04                                                                                        ^~~~~~~~~~~~~~~~~~~~~~~~
#18 94.04 /build/.build/checkouts/SwiftGD/Sources/SwiftGD/Format.swift:228:110: error: cannot find 'gdImageAvifPtr' in scope
#18 94.04      fileprivate let exportFunction: (gdImagePtr, UnsafeMutablePointer<Int32>) -> UnsafeMutableRawPointer? = gdImageAvifPtr
#18 94.04                                                                                                              ^~~~~~~~~~~~~~
#18 94.04 error: fatalError
#18 ERROR: process "/bin/sh -c swift build -c release --static-swift-stdlib" did not complete successfully: exit code: 1
------
 > [build  7/14] RUN swift build -c release --static-swift-stdlib:
92.36 [103/1418] Compiling CVaporBcrypt blf.c
93.21 [105/1420] Compiling _NIOBase64 Base64.swift
94.04 [106/1421] Compiling SwiftGD Color.swift
94.04 /build/.build/checkouts/SwiftGD/Sources/SwiftGD/Format.swift:225:88: error: cannot find 'gdImageCreateFromAvifPtr' in scope
94.04      fileprivate let importFunction: (Int32, UnsafeMutableRawPointer) -> gdImagePtr? = gdImageCreateFromAvifPtr
94.04                                                                                        ^~~~~~~~~~~~~~~~~~~~~~~~
94.04 /build/.build/checkouts/SwiftGD/Sources/SwiftGD/Format.swift:228:110: error: cannot find 'gdImageAvifPtr' in scope
94.04      fileprivate let exportFunction: (gdImagePtr, UnsafeMutablePointer<Int32>) -> UnsafeMutableRawPointer? = gdImageAvifPtr
94.04                                                                                                              ^~~~~~~~~~~~~~
94.04 error: fatalError
```