### PR TITLE
Fix image rotations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
       uses: SwiftyLab/setup-swift@latest
       with:
         swift-version: '5.10'
-    - name: Install libgd-dev
-      run: brew install gd
+    - name: Install libraries
+      run: brew install gd libexif libiptcdata
     - name: Build
       run: swift build
     - name: Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM swift:5.10-jammy as build
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get -q update \
     && apt-get -q dist-upgrade -y \
-    && apt-get install -y libgd-dev \
+    && apt-get install -y libgd-dev libiptc-data libexif-dev libiptcdata0-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Set up a build area
@@ -65,6 +65,9 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
       libcurl4 \
       libxml2 \
       libgd-dev \
+      libiptc-data \
+      libexif-dev \
+      libiptcdata0-dev \
     && rm -r /var/lib/apt/lists/*
 
 # Create a vapor user and group with /app as its home directory

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "87c2a2dede10840b0a6cf0836c7e22bc172c0b2fc744a7c0edc8d2c49d02394e",
+  "originHash" : "a542fdb969605bcdb2283e6e36f9c4f3ea469c68b3025119a4d97a0ce72621fb",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/queues.git",
       "state" : {
-        "revision" : "d867b5be81c612de5e048eb929784fed8df4affc",
-        "version" : "1.15.1"
+        "revision" : "be4ac720794a0cf931faa5a70224265b3d4820f0",
+        "version" : "1.16.0"
       }
     },
     {
@@ -339,8 +339,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
-        "version" : "1.1.2"
+        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
+        "version" : "1.1.3"
       }
     },
     {
@@ -348,8 +348,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "a53a7e8f858902659d4784322bede34f4e49097e",
-        "version" : "3.6.1"
+        "revision" : "9f95b4d033a4edd3814b48608db3f2ca90c7218b",
+        "version" : "3.7.0"
       }
     },
     {
@@ -411,8 +411,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "4c4453b489cf76e6b3b0f300aba663eb78182fad",
-        "version" : "2.70.0"
+        "revision" : "9746cf80e29edfef2a39924a66731249223f42a3",
+        "version" : "2.72.0"
       }
     },
     {
@@ -488,6 +488,15 @@
       }
     },
     {
+      "identity" : "swiftexif",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kradalby/SwiftExif.git",
+      "state" : {
+        "revision" : "ab83faa56618d14678279d3c93bb2fbc9070cb2b",
+        "version" : "0.0.7"
+      }
+    },
+    {
       "identity" : "swiftgd",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/twostraws/SwiftGD.git",
@@ -509,8 +518,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
       "state" : {
-        "revision" : "236025b6a213f372f81b732ff792f95789c089d4",
-        "version" : "4.104.0"
+        "revision" : "a4d7d4d32ef4a21dd10bc6375f4d20da3c5594e4",
+        "version" : "4.105.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -69,7 +69,10 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-docc-plugin.git", "1.0.0"..<"1.4.0"),
         
         // 🍲 SSwiftSoup: Pure Swift HTML Parser, with best of DOM, CSS, and jquery (Supports Linux, iOS, Mac, tvOS, watchOS).
-        .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.7.1")
+        .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.7.1"),
+        
+        // 📷 SwiftExif is a wrapping library for libexif and libiptcdata for Swift to provide a JPEG metadata extraction on Linux and macOS.
+        .package(url: "https://github.com/kradalby/SwiftExif.git", from: "0.0.0")
     ],
     targets: [
         .target(name: "ActivityPubKit", dependencies: [
@@ -101,7 +104,8 @@ let package = Package(
                 .product(name: "Ink", package: "Ink"),
                 .product(name: "SotoS3", package: "soto"),
                 .product(name: "Redis", package: "redis"),
-                .product(name: "SwiftSoup", package: "SwiftSoup")
+                .product(name: "SwiftSoup", package: "SwiftSoup"),
+                .product(name: "SwiftExif", package: "SwiftExif")
             ],
             swiftSettings: [
                 // Enable better optimizations when building in Release configuration. Despite the use of

--- a/Readme.md
+++ b/Readme.md
@@ -10,8 +10,24 @@ Application which is main API component for Vernissage photos sharing platform.
 
 ## Prerequisites
 
-Install the GD library on your computer. If you're using macOS, install Homebrew then run the command `brew install gd`.
-If you're using Linux, run `apt-get libgd-dev` as root.
+Three libraries are required to build/run the Vernissage API application: [GD](https://github.com/libgd/libgd), [libexif](https://github.com/libexif/libexif) and [libiptcdata](https://libiptcdata.sourceforge.net).
+These libraries are responsible mostly for image manipulation (resizing, converting, exif metadata, etc.).
+
+### macOs
+
+Using [Homebrew](https://brew.sh) you need to run following command:
+
+```bash
+$ brew install gd libexif libiptcdata
+```
+
+### Linux
+
+If you're using Linux you need to run following command as root.
+
+```bash
+$ apt install -y libgd-dev libiptc-data libexif-dev libiptcdata0-dev
+```
 
 ## Architecture
 

--- a/Sources/VernissageServer/Controllers/AvatarsController.swift
+++ b/Sources/VernissageServer/Controllers/AvatarsController.swift
@@ -118,8 +118,16 @@ final class AvatarsController {
             throw AvatarError.createResizedImageFailed
         }
         
+        // Read Exif orientation.
+        let orientation = ImageOrientation(fileUrl: tmpFileUrl, on: request.application)
+
+        // Rotate based on orientation.
+        guard let rotatedImage = image.rotate(basedOn: orientation) else {
+            throw AttachmentError.imageRotationFailed
+        }
+        
         // Resize image.
-        guard let resized = image.resizedTo(width: 600, height: 600) else {
+        guard let resized = rotatedImage.resizedTo(width: 600, height: 600) else {
             throw AvatarError.resizedImageFailed
         }
         

--- a/Sources/VernissageServer/Controllers/HeadersController.swift
+++ b/Sources/VernissageServer/Controllers/HeadersController.swift
@@ -118,8 +118,16 @@ final class HeadersController {
             throw HeaderError.createResizedImageFailed
         }
         
+        // Read Exif orientation.
+        let orientation = ImageOrientation(fileUrl: tmpFileUrl, on: request.application)
+
+        // Rotate based on orientation.
+        guard let rotatedImage = image.rotate(basedOn: orientation) else {
+            throw AttachmentError.imageRotationFailed
+        }
+        
         // Resize image.
-        guard let resized = image.resizedTo(width: 1500, height: 500) else {
+        guard let resized = rotatedImage.resizedTo(width: 1500, height: 500) else {
             throw HeaderError.resizedImageFailed
         }
         

--- a/Sources/VernissageServer/Errors/AttachmentError.swift
+++ b/Sources/VernissageServer/Errors/AttachmentError.swift
@@ -12,7 +12,8 @@ enum AttachmentError: String, Error {
     case missingImage
     case savedFailed
     case createResizedImageFailed
-    case resizedImageFailed
+    case imageRotationFailed
+    case imageResizeFailed
     case attachmentAlreadyConnectedToStatus
     case imageTooLarge
 }
@@ -21,7 +22,7 @@ extension AttachmentError: LocalizedTerminateError {
     var status: HTTPResponseStatus {
         switch self {
         case .missingImage, .attachmentAlreadyConnectedToStatus: return .badRequest
-        case .savedFailed, .createResizedImageFailed, .resizedImageFailed: return .internalServerError
+        case .savedFailed, .createResizedImageFailed, .imageRotationFailed, .imageResizeFailed: return .internalServerError
         case .imageTooLarge: return .payloadTooLarge
         }
     }
@@ -31,7 +32,8 @@ extension AttachmentError: LocalizedTerminateError {
         case .missingImage: return "Image is not attached into the request."
         case .savedFailed: return "Saving file failed."
         case .createResizedImageFailed: return "Cannot create image for resizing."
-        case .resizedImageFailed: return "Image cannot be resized."
+        case .imageRotationFailed: return "Image cannot be rotated."
+        case .imageResizeFailed: return "Image cannot be resized."
         case .attachmentAlreadyConnectedToStatus: return "Attachment already connected to status."
         case .imageTooLarge: return "Image file is too large."
         }

--- a/Sources/VernissageServer/Extensions/Image+Orientation.swift
+++ b/Sources/VernissageServer/Extensions/Image+Orientation.swift
@@ -1,0 +1,51 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2024 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+import Foundation
+import SwiftGD
+import SwiftExif
+
+extension SwiftGD.Image {
+    func orientation(fileUrl: URL, on application: Application) -> ImageOrientation {
+        let exifImage = SwiftExif.Image(imagePath: fileUrl)
+        let exifData = exifImage.Exif()
+        
+        guard let orientation = exifData["0"]?["Orientation"] else {
+            return .horizontalNormal
+        }
+        
+        guard let orientationEnum = ImageOrientation(rawValue: orientation) else {
+            application.logger.warning("Image orientation '\(orientation)' has not been correctly identified.")
+            return .horizontalNormal
+        }
+        
+        return orientationEnum
+    }
+    
+    func rotate(basedOn orientation: ImageOrientation) -> SwiftGD.Image? {
+        switch orientation {
+        case .horizontalNormal:
+            return self
+        case .mirrorHorizontal:
+            return self.flipped(.horizontal)
+        case .rotate180:
+            return self.rotated(.degrees(-180))
+        case .mirrorVertical:
+            return self.flipped(.vertical)
+        case .mirrorHorizontalAndRotate270CW:
+            let rotated = self.rotated(.degrees(-90))
+            return rotated?.flipped(.horizontal)
+        case .rotate90CW:
+            return self.rotated(.degrees(-90))
+        case .mirrorHorizontalAndRotate90CW:
+            let rotated = self.rotated(.degrees(-90))
+            return rotated?.flipped(.vertical)
+        case .rotate270CW:
+            return self.rotated(.degrees(-270))
+        }
+    }
+}

--- a/Sources/VernissageServer/Models/ImageOrientation.swift
+++ b/Sources/VernissageServer/Models/ImageOrientation.swift
@@ -1,0 +1,55 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2024 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Foundation
+import Vapor
+import SwiftExif
+
+public enum ImageOrientation: String {
+    
+    // Top-left.
+    case horizontalNormal = "1"
+    
+    // Top-right.
+    case mirrorHorizontal = "2"
+
+    // Bottom-right.
+    case rotate180 = "3"
+    
+    // Bottom-left.
+    case mirrorVertical = "4"
+    
+    // Left-top.
+    case mirrorHorizontalAndRotate270CW = "5"
+    
+    // Right-top.
+    case rotate90CW = "6"
+    
+    // Right-bottom.
+    case mirrorHorizontalAndRotate90CW = "7"
+    
+    // Left-bottom.
+    case rotate270CW = "8"
+    
+    init(fileUrl: URL, on application: Application) {
+        let exifImage = SwiftExif.Image(imagePath: fileUrl)
+        let exifData = exifImage.ExifRaw()
+        
+        guard let orientation = exifData["0"]?["Orientation"] else {
+            self = .horizontalNormal
+            return
+        }
+        
+        guard let orientationEnum = ImageOrientation(rawValue: orientation) else {
+            application.logger.warning("Image orientation '\(orientation)' has not been correctly identified.")
+
+            self = .horizontalNormal
+            return
+        }
+        
+        self = orientationEnum
+    }
+}

--- a/Sources/VernissageServer/Services/StatusesService.swift
+++ b/Sources/VernissageServer/Services/StatusesService.swift
@@ -1377,7 +1377,7 @@ final class StatusesService: StatusesServiceType {
         // Resize image.
         context.logger.info("Resizing image '\(attachment.url)'.")
         guard let resized = image.resizedTo(width: 800) else {
-            throw AttachmentError.resizedImageFailed
+            throw AttachmentError.imageResizeFailed
         }
         
         // Get fileName from URL.

--- a/Sources/VernissageServer/VernissageServer.docc/HostVernissageServer.md
+++ b/Sources/VernissageServer/VernissageServer.docc/HostVernissageServer.md
@@ -13,10 +13,26 @@ We can run it in all operating systems supporting `Swift` and `Vapor`.
 
 ## Prerequisites
 
-Install the `GD` library on your computer. If you're using macOS, install Homebrew then run the command `brew install gd`.
-If you're using Linux, run `apt-get libgd-dev` as root.
-
 Running the application requires installing [Swift](https://www.swift.org/install/).
+
+Three libraries are required to build/run the Vernissage API application: [GD](https://github.com/libgd/libgd), [libexif](https://github.com/libexif/libexif) and [libiptcdata](https://libiptcdata.sourceforge.net).
+These libraries are responsible mostly for image manipulation (resizing, converting, exif metadata, etc.).
+
+### macOs
+
+Using [Homebrew](https://brew.sh) you need to run following command:
+
+```bash
+$ brew install gd libexif libiptcdata
+```
+
+### Linux
+
+If you're using Linux you need to run following command as root.
+
+```bash
+$ apt install -y libgd-dev libiptc-data libexif-dev libiptcdata0-dev
+```
 
 ## Getting started
 


### PR DESCRIPTION
During file upload (before resizing) we have to rotate image according to image metadata. After resizing the whole image metadata are removed, thus browser will render image as it is (there is no information about original device rotation).