### PR TITLE
Fix generating snowflake id's with multiple instances configuration

### DIFF
--- a/Sources/VernissageServer/Application+Configure.swift
+++ b/Sources/VernissageServer/Application+Configure.swift
@@ -65,8 +65,8 @@ extension Application {
     }
 
     private func initSnowflakesGenerator() {
-        // Frostflake.setup(sharedGenerator: Frostflake(generatorIdentifier: 1))
         self.services.snowflakeService = SnowflakeService()
+        self.logger.info("Snowflake id generator has been initialized with node id: '\(self.services.snowflakeService.getNodeId())'.")
     }
     
     /// Register your application's routes here.

--- a/Sources/VernissageServer/Services/SnowflakeService.swift
+++ b/Sources/VernissageServer/Services/SnowflakeService.swift
@@ -27,14 +27,24 @@ extension Application.Services {
 @_documentation(visibility: private)
 protocol SnowflakeServiceType: Sendable {
     func generate() -> Int64
+    func getNodeId() -> UInt16
 }
 
 /// A service for generating snowflake style identifiers (used as primary key in database).
 final class SnowflakeService: SnowflakeServiceType {
     let frostflake: Frostflake
+    let nodeId: UInt16
     
     init() {
-        frostflake = Frostflake(generatorIdentifier: 1)
+        // Node id is randomly generated for each API instance (that should reduce collisions).
+        nodeId = UInt16.random(in: 1..<1000)
+        
+        // We have to force time regeneration during each id generation to be sure that id's have proper order between instances.
+        frostflake = Frostflake(generatorIdentifier: nodeId, forcedTimeRegenerationInterval: 1)
+    }
+    
+    func getNodeId() -> UInt16 {
+        self.nodeId
     }
     
     func generate() -> Int64 {


### PR DESCRIPTION
When we have multiple API instances we have to be sure that in each id there is fresh timestamp, in other case we have an id's generated by different nodes with strange order (newest post are in the middle in the timeline).