### PR TITLE
Return category hashtags with list of categories

### DIFF
--- a/Sources/VernissageServer/Controllers/CategoriesController.swift
+++ b/Sources/VernissageServer/Controllers/CategoriesController.swift
@@ -88,6 +88,7 @@ struct CategoriesController {
         let onlyUsed: Bool = request.query["onlyUsed"] ?? false
         
         let categories = try await Category.query(on: request.db)
+            .with(\.$hashtags)
             .sort(\.$name, .ascending)
             .all()
         
@@ -102,9 +103,9 @@ struct CategoriesController {
                 }
             }
             
-            return usedCategories.map({ CategoryDto(from: $0) })
+            return usedCategories.map({ CategoryDto(from: $0, with: $0.hashtags) })
         }
         
-        return categories.map({ CategoryDto(from: $0) })
+        return categories.map({ CategoryDto(from: $0, with: $0.hashtags) })
     }
 }

--- a/Sources/VernissageServer/DataTransferObjects/CategoryDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/CategoryDto.swift
@@ -9,11 +9,13 @@ import Vapor
 struct CategoryDto {
     var id: String?
     var name: String
+    var hashtags: [CategoryHashtagDto]?
 }
 
 extension CategoryDto {
-    init(from category: Category) {
-        self.init(id: category.stringId(), name: category.name)
+    init(from category: Category, with hashtags: [CategoryHashtag]) {
+        let hashtagDtos = hashtags.map { CategoryHashtagDto(from: $0) }
+        self.init(id: category.stringId(), name: category.name, hashtags: hashtagDtos)
     }
     
     init?(from category: Category?) {

--- a/Sources/VernissageServer/DataTransferObjects/CategoryHashtagDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/CategoryHashtagDto.swift
@@ -1,0 +1,26 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Fluent
+import Vapor
+import ActivityPubKit
+
+
+struct CategoryHashtagDto {
+    var id: String?
+    var hashtag: String
+    var hashtagNormalized: String
+}
+
+extension CategoryHashtagDto {
+    init(from categoryHashtag: CategoryHashtag) {
+        self.id = categoryHashtag.stringId()
+        self.hashtag = categoryHashtag.hashtag
+        self.hashtagNormalized = categoryHashtag.hashtagNormalized
+    }
+}
+
+extension CategoryHashtagDto: Content { }

--- a/Sources/VernissageServer/Extensions/Application+Seed.swift
+++ b/Sources/VernissageServer/Extensions/Application+Seed.swift
@@ -559,7 +559,7 @@ extension Application {
             "Nature": ["nature", "trees", "forest"],
             "Night": ["night"],
             "Nude": ["nude", "porn", "act", "nudity", "artnude", "fineartnude", "nudeart", "nudemodel"],
-            "People": ["people", "person"],
+            "People": ["people", "person", "silhouette", "portrait", "character", "woman", "female", "man", "male", "girl"],
             "Sport": ["sport", "football", "tenis", "soccer"],
             "Still Life": ["still", "stilllife"],
             "Street": ["street", "streetphotography"],

--- a/Tests/VernissageServerTests/AcceptanceTests/CategoriesController/CategoriesListActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/CategoriesController/CategoriesListActionTests.swift
@@ -35,6 +35,7 @@ extension ControllersTests {
             
             // Assert.
             #expect(categories.count > 0, "Categories list should be returned.")
+            #expect((categories.first?.hashtags?.count ?? 0) > 0, "Category hashtags list should be returned.")
         }
         
         @Test("Categories list should be returned for only used parameter")


### PR DESCRIPTION
Categories contains hashtags which are used during category matching when we are retrieving remote categories. We should return these hashtags with category list.