### PR TITLE
Fix displaying usernames with dots in rendered html

### DIFF
--- a/Sources/VernissageServer/Extensions/String+HTML.swift
+++ b/Sources/VernissageServer/Extensions/String+HTML.swift
@@ -66,7 +66,7 @@ extension String {
     }
     
     private func convertUsernamesIntoHtml(baseAddress: String) -> String {
-        let usernamePattern = #/(?<prefix>^|[ +\-=!<>,\.:;*"'{}]{1})(?<username>@[a-zA-Z0-9(_)]{1,})(?<domain>[@]{1}[a-zA-Z0-9_\-\.]{0,}){0,}/#
+        let usernamePattern = #/(?<prefix>^|[ +\-=!<>,\.:;*"'{}]{1})(?<username>@[\w](?:[\w\.+-]*[\w])?)(?<domain>@[\w](?:[\w\.+-]*[\w])?){0,}/#
         return self.replacing(usernamePattern) { match in
             let matchedDomain =  match.domain ?? ""
             let domain = matchedDomain.isEmpty ? baseAddress : "https://\(String(matchedDomain).deletingPrefix("@"))"

--- a/Tests/VernissageServerTests/ExtensionsTests/String+Html.swift
+++ b/Tests/VernissageServerTests/ExtensionsTests/String+Html.swift
@@ -44,6 +44,40 @@ struct StringHtmlTests {
         #expect(html == expectedHtml)
     }
     
+    @Test("Rendering single url address with dot")
+    func renderingSingleUrlAddressWithDot() async throws {
+        
+        // Arrange.
+        let text = "@marcin.test@other.uk Comment test"
+        
+        // Act.
+        let html = text.html(baseAddress: "https://vernissage.com", wrapInParagraph: true)
+        
+        // Assert.
+        let expectedHtml =
+"""
+<p><a href="https://other.uk/@marcin.test" class="username">@marcin.test@other.uk</a> Comment test</p>
+"""
+        #expect(html == expectedHtml)
+    }
+    
+    @Test("Rendering single url address with dot at the end of sentance")
+    func renderingSingleUrlAddressWithDotAtTheEndOfSentance() async throws {
+        
+        // Arrange.
+        let text = "Here is the user @marcin.test@other.uk."
+        
+        // Act.
+        let html = text.html(baseAddress: "https://vernissage.com", wrapInParagraph: true)
+        
+        // Assert.
+        let expectedHtml =
+"""
+<p>Here is the user <a href="https://other.uk/@marcin.test" class="username">@marcin.test@other.uk</a>.</p>
+"""
+        #expect(html == expectedHtml)
+    }
+    
     @Test("Rendering single url with text address")
     func renderingSingleUrlWithTextAddress() async throws {
         


### PR DESCRIPTION
Fixing showing user names which looks like that: @user.name@server.com.