### PR TITLE
#198 Fix descendants in context endpoint

### DIFF
--- a/Sources/VernissageServer/Controllers/StatusesController.swift
+++ b/Sources/VernissageServer/Controllers/StatusesController.swift
@@ -372,7 +372,13 @@ struct StatusesController {
                 try await statusMention.save(on: database)
             }
             
+            // We have to update number of user's statuses counter.
             try await request.application.services.statusesService.updateStatusCount(for: authorizationPayloadId, on: database)
+            
+            // We have to update number of statuses replies.
+            if let replyToStatusId = statusRequestDto.replyToStatusId?.toId() {
+                try await request.application.services.statusesService.updateRepliesCount(for: replyToStatusId, on: database)
+            }
         }
         
         let statusFromDatabase = try await request.application.services.statusesService.get(id: status.requireID(), on: request.db)

--- a/Sources/VernissageServer/Models/Status.swift
+++ b/Sources/VernissageServer/Models/Status.swift
@@ -178,3 +178,11 @@ final class Status: Model, @unchecked Sendable {
 
 /// Allows `Status` to be encoded to and decoded from HTTP messages.
 extension Status: Content { }
+
+extension [Status] {
+    func sorted() -> [Status] {
+        self.sorted { left, right in
+            (left.id ?? 0) < (right.id ?? 0)
+        }
+    }
+}

--- a/TestRequests/StatusesController/context.bru
+++ b/TestRequests/StatusesController/context.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/api/v1/statuses/7358858409322510337/context
+  url: {{host}}/api/v1/statuses/7457103003078627879/context
   body: none
   auth: bearer
 }

--- a/Tests/VernissageServerTests/AcceptanceTests/StatusesController/StatusesCreateActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/StatusesController/StatusesCreateActionTests.swift
@@ -139,6 +139,9 @@ extension ControllersTests {
             let savedStatus = try await application.getStatus(id: createdStatusDto.id?.toId() ?? 0)
             #expect(savedStatus != nil, "Status have to be saved.")
             #expect(savedStatus?.$mainReplyToStatus.id == status1.id, "Main status id have to be saved for coments.")
+            
+            let parentStatus = try await application.getStatus(id: status1.id ?? 0)
+            #expect(parentStatus?.repliesCount == 1, "Replies count of parent status have to be updated.")
         }
         
         @Test("Status should not be created for unauthorized user")


### PR DESCRIPTION
Now `context` endpoint will return all descendants in the array (thanks to this we can do only one request for all comments.