### PR TITLE
Shared business cards feature

### DIFF
--- a/Sources/VernissageServer/Application+Configure.swift
+++ b/Sources/VernissageServer/Application+Configure.swift
@@ -129,6 +129,8 @@ extension Application {
         try self.register(collection: AtomController())
         try self.register(collection: FollowingImportsController())
         try self.register(collection: ArticlesController())
+        try self.register(collection: BusinessCardsController())
+        try self.register(collection: SharedBusinessCardsController())
         
         // Profile controller shuld be the last one (it registers: https://example.com/@johndoe).
         try self.register(collection: ProfileController())
@@ -344,6 +346,11 @@ extension Application {
         self.migrations.add(Article.CreateArticles())
         self.migrations.add(ArticleVisibility.CreateArticleVisibilities())
         self.migrations.add(ArticleRead.CreateArticleReads())
+        
+        self.migrations.add(BusinessCard.CreateBusinessCards())
+        self.migrations.add(BusinessCardField.CreateBusinessCardFields())
+        self.migrations.add(SharedBusinessCard.CreateSharedBusinessCards())
+        self.migrations.add(SharedBusinessCardMessage.CreateSharedBusinessCardMessages())
         
         try await self.autoMigrate()
     }

--- a/Sources/VernissageServer/Constants.swift
+++ b/Sources/VernissageServer/Constants.swift
@@ -9,7 +9,7 @@ import Vapor
 /// Basic constants used in the system.
 public final class Constants {
     public static let name = "Vernissage"
-    public static let version = "1.11.0-buildx"
+    public static let version = "1.12.0-buildx"
     public static let applicationName = "\(Constants.name) \(Constants.version)"
     public static let userAgent = "(\(Constants.name)/\(Constants.version))"
     public static let requestMetadata = "Request body"

--- a/Sources/VernissageServer/Controllers/BusinessCardsController.swift
+++ b/Sources/VernissageServer/Controllers/BusinessCardsController.swift
@@ -1,0 +1,471 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+import Fluent
+import ActivityPubKit
+
+extension BusinessCardsController: RouteCollection {
+    
+    @_documentation(visibility: private)
+    static let uri: PathComponent = .constant("business-cards")
+    
+    func boot(routes: RoutesBuilder) throws {
+        let businessCardsGroup = routes
+            .grouped("api")
+            .grouped("v1")
+            .grouped(BusinessCardsController.uri)
+            .grouped(UserAuthenticator())
+                
+        businessCardsGroup
+            .grouped(UserPayload.guardMiddleware())
+            .grouped(EventHandlerMiddleware(.businessCardsRead))
+            .grouped(CacheControlMiddleware(.noStore))
+            .get(use: read)
+        
+        businessCardsGroup
+            .grouped(UserPayload.guardMiddleware())
+            .grouped(XsrfTokenValidatorMiddleware())
+            .grouped(EventHandlerMiddleware(.businessCardsCreate))
+            .grouped(CacheControlMiddleware(.noStore))
+            .post(use: create)
+        
+        businessCardsGroup
+            .grouped(UserPayload.guardMiddleware())
+            .grouped(XsrfTokenValidatorMiddleware())
+            .grouped(EventHandlerMiddleware(.businessCardsUpdate))
+            .grouped(CacheControlMiddleware(.noStore))
+            .put(use: update)
+    }
+}
+
+/// Exposing user's business card.
+///
+/// Endpoint is returning the information about user's business card. Business card can be shared with third party.
+///
+/// > Important: Base controller URL: `/api/v1/business-cards`.
+struct BusinessCardsController {
+        
+    /// Get existing user's business card.
+    ///
+    /// The endpoint can be used for downloading existing user's business card.
+    /// User can have one business card.
+    ///
+    /// > Important: Endpoint URL: `/api/v1/business-cards`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/business-cards" \
+    /// -X GET \
+    /// -H "Content-Type: application/json" \
+    /// -H "Authorization: Bearer [ACCESS_TOKEN]"
+    /// ```
+    ///
+    /// **Example response body:**
+    ///
+    /// ```json
+    /// {
+    ///     "body": "Software engineer (favorite technologies: #Swift/#dotNET/#Angular)",
+    ///     "color1": "#ad5389",
+    ///     "color2": "#3c1053",
+    ///     "color3": "#ffffff",
+    ///     "createdAt": "2025-04-28T11:48:54.321Z",
+    ///     "email": "",
+    ///     "fields": [
+    ///         {
+    ///             "createdAt": "2025-04-28T11:48:54.324Z",
+    ///             "id": "7498329715548099199",
+    ///             "key": "MASTODON",
+    ///             "updatedAt": "2025-04-28T11:48:54.324Z",
+    ///             "value": "https://user.dev"
+    ///         },
+    ///         {
+    ///             "createdAt": "2025-04-28T11:48:54.324Z",
+    ///             "id": "7498329715548101247",
+    ///             "key": "WEBSITE",
+    ///             "updatedAt": "2025-04-28T11:48:54.324Z",
+    ///             "value": "https://developer.dev"
+    ///         }
+    ///     ],
+    ///     "id": "7498329715548097151",
+    ///     "subtitle": "@johndoe",
+    ///     "telephone": "",
+    ///     "title": "John Doe",
+    ///     "updatedAt": "2025-04-28T11:48:54.321Z",
+    ///     "user": { ... },
+    ///     "website": ""
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    ///
+    /// - Returns: Entity data.
+    @Sendable
+    func read(request: Request) async throws -> BusinessCardDto {
+        guard let authorizationPayloadId = request.userId else {
+            throw Abort(.forbidden)
+        }
+        
+        guard let businessCardFromDatabase = try await BusinessCard.query(on: request.db)
+            .with(\.$user)
+            .with(\.$businessCardFields)
+            .filter(\.$user.$id == authorizationPayloadId)
+            .first() else {
+            throw EntityNotFoundError.businessCardNotFound
+        }
+
+        let businessCardsService = request.application.services.businessCardsService
+        return businessCardsService.convertToDto(businessCard: businessCardFromDatabase, on: request.executionContext)
+    }
+    
+    /// Create new user's business card.
+    ///
+    /// The endpoint can be used for creating new user's business card.
+    ///
+    /// > Important: Endpoint URL: `/api/v1/business-cards`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/business-cards" \
+    /// -X POST \
+    /// -H "Content-Type: application/json" \
+    /// -H "Authorization: Bearer [ACCESS_TOKEN]" \
+    /// -d '{ ... }'
+    /// ```
+    ///
+    /// **Example request body:**
+    ///
+    /// ```json
+    /// {
+    ///     "body": "Software engineer (favorite technologies: #Swift/#dotNET/#Angular)",
+    ///     "color1": "#ad5389",
+    ///     "color2": "#3c1053",
+    ///     "color3": "#ffffff",
+    ///     "email": "",
+    ///     "fields": [
+    ///         {
+    ///             "createdAt": "2025-04-28T11:48:54.324Z",
+    ///             "id": "7498329715548099199",
+    ///             "key": "MASTODON",
+    ///             "updatedAt": "2025-04-28T11:48:54.324Z",
+    ///             "value": "https://user.dev"
+    ///         },
+    ///         {
+    ///             "createdAt": "2025-04-28T11:48:54.324Z",
+    ///             "id": "7498329715548101247",
+    ///             "key": "WEBSITE",
+    ///             "updatedAt": "2025-04-28T11:48:54.324Z",
+    ///             "value": "https://developer.dev"
+    ///         }
+    ///     ],
+    ///     "id": "7498329715548097151",
+    ///     "subtitle": "@johndoe",
+    ///     "telephone": "",
+    ///     "title": "John Doe",
+    ///     "website": ""
+    /// }
+    /// ```
+    ///
+    /// **Example response body:**
+    ///
+    /// ```json
+    /// {
+    ///     "body": "Software engineer (favorite technologies: #Swift/#dotNET/#Angular)",
+    ///     "color1": "#ad5389",
+    ///     "color2": "#3c1053",
+    ///     "color3": "#ffffff",
+    ///     "createdAt": "2025-04-28T11:48:54.321Z",
+    ///     "email": "",
+    ///     "fields": [
+    ///         {
+    ///             "createdAt": "2025-04-28T11:48:54.324Z",
+    ///             "id": "7498329715548099199",
+    ///             "key": "MASTODON",
+    ///             "updatedAt": "2025-04-28T11:48:54.324Z",
+    ///             "value": "https://user.dev"
+    ///         },
+    ///         {
+    ///             "createdAt": "2025-04-28T11:48:54.324Z",
+    ///             "id": "7498329715548101247",
+    ///             "key": "WEBSITE",
+    ///             "updatedAt": "2025-04-28T11:48:54.324Z",
+    ///             "value": "https://developer.dev"
+    ///         }
+    ///     ],
+    ///     "id": "7498329715548097151",
+    ///     "subtitle": "@johndoe",
+    ///     "telephone": "",
+    ///     "title": "John Doe",
+    ///     "updatedAt": "2025-04-28T11:48:54.321Z",
+    ///     "user": { ... },
+    ///     "website": ""
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    ///
+    /// - Returns: New added entity.
+    @Sendable
+    func create(request: Request) async throws -> Response {
+        guard let authorizationPayloadId = request.userId else {
+            throw Abort(.forbidden)
+        }
+        
+        let businessCardDto = try request.content.decode(BusinessCardDto.self)
+        try BusinessCardDto.validate(content: request)
+        
+        let newBusinessCardId = request.application.services.snowflakeService.generate()
+        let businessCard = BusinessCard(id: newBusinessCardId,
+                                        userId: authorizationPayloadId,
+                                        title: businessCardDto.title,
+                                        subtitle: businessCardDto.subtitle,
+                                        body: businessCardDto.body,
+                                        website: businessCardDto.website,
+                                        telephone: businessCardDto.telephone,
+                                        email: businessCardDto.email,
+                                        color1: businessCardDto.color1,
+                                        color2: businessCardDto.color2,
+                                        color3: businessCardDto.color3)
+        
+        var businessCardFields: [BusinessCardField] = []
+        
+        if let fields = businessCardDto.fields {
+            for field in fields {
+                let newFieldId = request.application.services.snowflakeService.generate()
+                let newBusinessCardField = BusinessCardField(id: newFieldId,
+                                                             businessCardId: newBusinessCardId,
+                                                             key: field.key,
+                                                             value: field.value)
+                
+                businessCardFields.append(newBusinessCardField)
+            }
+        }
+        
+        let businessCardFieldsToSave = businessCardFields
+        try await request.db.transaction { database in
+            try await businessCard.save(on: database)
+            
+            for businessCardFieldToSave in businessCardFieldsToSave {
+                try await businessCardFieldToSave.save(on: database)
+            }
+        }
+                
+        guard let businessCardFromDatabase = try await BusinessCard.query(on: request.db)
+            .with(\.$user)
+            .with(\.$businessCardFields)
+            .filter(\.$user.$id == authorizationPayloadId)
+            .first() else {
+            throw EntityNotFoundError.businessCardNotFound
+        }
+                
+        return try await createBusinessCardResponse(on: request, businessCard: businessCardFromDatabase)
+    }
+    
+    /// Update existing user's business card.
+    ///
+    /// The endpoint can be used for updating existing user's business card.
+    ///
+    /// > Important: Endpoint URL: `/api/v1/business-cards`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/business-cards" \
+    /// -X POST \
+    /// -H "Content-Type: application/json" \
+    /// -H "Authorization: Bearer [ACCESS_TOKEN]" \
+    /// -d '{ ... }'
+    /// ```
+    ///
+    /// **Example request body:**
+    ///
+    /// ```json
+    /// {
+    ///     "body": "Software engineer (favorite technologies: #Swift/#dotNET/#Angular)",
+    ///     "color1": "#ad5389",
+    ///     "color2": "#3c1053",
+    ///     "color3": "#ffffff",
+    ///     "email": "",
+    ///     "fields": [
+    ///         {
+    ///             "createdAt": "2025-04-28T11:48:54.324Z",
+    ///             "id": "7498329715548099199",
+    ///             "key": "MASTODON",
+    ///             "updatedAt": "2025-04-28T11:48:54.324Z",
+    ///             "value": "https://user.dev"
+    ///         },
+    ///         {
+    ///             "createdAt": "2025-04-28T11:48:54.324Z",
+    ///             "id": "7498329715548101247",
+    ///             "key": "WEBSITE",
+    ///             "updatedAt": "2025-04-28T11:48:54.324Z",
+    ///             "value": "https://developer.dev"
+    ///         }
+    ///     ],
+    ///     "id": "7498329715548097151",
+    ///     "subtitle": "@johndoe",
+    ///     "telephone": "",
+    ///     "title": "John Doe",
+    ///     "website": ""
+    /// }
+    /// ```
+    ///
+    /// **Example response body:**
+    ///
+    /// ```json
+    /// {
+    ///     "body": "Software engineer (favorite technologies: #Swift/#dotNET/#Angular)",
+    ///     "color1": "#ad5389",
+    ///     "color2": "#3c1053",
+    ///     "color3": "#ffffff",
+    ///     "createdAt": "2025-04-28T11:48:54.321Z",
+    ///     "email": "",
+    ///     "fields": [
+    ///         {
+    ///             "createdAt": "2025-04-28T11:48:54.324Z",
+    ///             "id": "7498329715548099199",
+    ///             "key": "MASTODON",
+    ///             "updatedAt": "2025-04-28T11:48:54.324Z",
+    ///             "value": "https://user.dev"
+    ///         },
+    ///         {
+    ///             "createdAt": "2025-04-28T11:48:54.324Z",
+    ///             "id": "7498329715548101247",
+    ///             "key": "WEBSITE",
+    ///             "updatedAt": "2025-04-28T11:48:54.324Z",
+    ///             "value": "https://developer.dev"
+    ///         }
+    ///     ],
+    ///     "id": "7498329715548097151",
+    ///     "subtitle": "@johndoe",
+    ///     "telephone": "",
+    ///     "title": "John Doe",
+    ///     "updatedAt": "2025-04-28T11:48:54.321Z",
+    ///     "user": { ... },
+    ///     "website": ""
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    ///
+    /// - Returns: Updated entity.
+    @Sendable
+    func update(request: Request) async throws -> BusinessCardDto {
+        guard let authorizationPayloadId = request.userId else {
+            throw Abort(.forbidden)
+        }
+        
+        let businessCardDto = try request.content.decode(BusinessCardDto.self)
+        try BusinessCardDto.validate(content: request)
+                
+        guard let businessCardFromDatabase = try await BusinessCard.query(on: request.db)
+            .with(\.$user)
+            .with(\.$businessCardFields)
+            .filter(\.$user.$id == authorizationPayloadId)
+            .first() else {
+            throw EntityNotFoundError.businessCardNotFound
+        }
+        
+        businessCardFromDatabase.title = businessCardDto.title
+        businessCardFromDatabase.subtitle = businessCardDto.subtitle
+        businessCardFromDatabase.body = businessCardDto.body
+        businessCardFromDatabase.website = businessCardDto.website
+        businessCardFromDatabase.telephone = businessCardDto.telephone
+        businessCardFromDatabase.email = businessCardDto.email
+        businessCardFromDatabase.color1 = businessCardDto.color1
+        businessCardFromDatabase.color2 = businessCardDto.color2
+        businessCardFromDatabase.color3 = businessCardDto.color3
+        
+        var businessCardFieldToAdd: [BusinessCardField] = []
+        var businessCardFieldToDelete: [BusinessCardField] = []
+        var businessCardFieldToUpdate: [BusinessCardField] = []
+        let fields = businessCardDto.fields ?? []
+        
+        // Calculate fields to update and delete.
+        for businessCardFieldFromDb in businessCardFromDatabase.businessCardFields {
+            if let flexiFieldDto = fields.first(where: { $0.id == businessCardFieldFromDb.stringId() }) {
+                if flexiFieldDto.key == "" && flexiFieldDto.value == "" {
+                    // User cleared key and value thus we can delete the whole row.
+                    businessCardFieldToDelete.append(businessCardFieldFromDb)
+                } else {
+                    // Update existing one.
+                    businessCardFieldFromDb.key = flexiFieldDto.key
+                    businessCardFieldFromDb.value = flexiFieldDto.value
+                    
+                    businessCardFieldToUpdate.append(businessCardFieldFromDb)
+                }
+            } else {
+                // Remember what to delete.
+                businessCardFieldToDelete.append(businessCardFieldFromDb)
+            }
+        }
+        
+        // Calculate fields to add.
+        for flexiFieldDto in fields {
+            if flexiFieldDto.key == "" && flexiFieldDto.value == "" {
+                continue
+            }
+            
+            if businessCardFromDatabase.businessCardFields.contains(where: { $0.stringId() == flexiFieldDto.id }) == false {
+                let newBusinessCardFieldId = request.application.services.snowflakeService.generate()
+                let newBusinessCardField = try BusinessCardField(id: newBusinessCardFieldId,
+                                                                 businessCardId: businessCardFromDatabase.requireID(),
+                                                                 key: flexiFieldDto.key,
+                                                                 value: flexiFieldDto.value)
+                
+                businessCardFieldToAdd.append(newBusinessCardField)
+            }
+        }
+        
+        
+        let businessCardFieldToDatabaseAdd = businessCardFieldToAdd
+        let businessCardFieldToDatabaseDelete = businessCardFieldToDelete
+        let businessCardFieldToDatabaseUpdate = businessCardFieldToUpdate
+
+        // Save everything to database in one transaction.
+        try await request.db.transaction { database in
+            try await businessCardFromDatabase.save(on: database)
+
+            for businessCardField in businessCardFieldToDatabaseDelete {
+                try await businessCardField.delete(on: database)
+            }
+            
+            for businessCardField in businessCardFieldToDatabaseUpdate {
+                try await businessCardField.update(on: database)
+            }
+            
+            for businessCardField in businessCardFieldToDatabaseAdd {
+                try await businessCardField.create(on: database)
+            }
+        }
+        
+        guard let businessCardFromDatabase = try await BusinessCard.query(on: request.db)
+            .with(\.$user)
+            .with(\.$businessCardFields)
+            .filter(\.$user.$id == authorizationPayloadId)
+            .first() else {
+            throw EntityNotFoundError.businessCardNotFound
+        }
+
+        let businessCardsService = request.application.services.businessCardsService
+        return businessCardsService.convertToDto(businessCard: businessCardFromDatabase, on: request.executionContext)
+    }
+    
+    private func createBusinessCardResponse(on request: Request, businessCard: BusinessCard) async throws -> Response {
+        let businessCardsService = request.application.services.businessCardsService
+        let businessCardDto = businessCardsService.convertToDto(businessCard: businessCard, on: request.executionContext)
+        
+        var headers = HTTPHeaders()
+        headers.replaceOrAdd(name: .location, value: "/\(BusinessCardsController.uri)/@\(businessCard.stringId() ?? "")")
+        
+        return try await businessCardDto.encodeResponse(status: .created, headers: headers, for: request)
+    }
+}

--- a/Sources/VernissageServer/Controllers/SettingsController.swift
+++ b/Sources/VernissageServer/Controllers/SettingsController.swift
@@ -178,6 +178,7 @@ struct SettingsController {
                                                   webPushVapidPublicKey: webPushVapidPublicKey,
                                                   imagesUrl: imagesUrl,
                                                   showNews: settings.showNews,
+                                                  showSharedBusinessCards: settings.showSharedBusinessCards,
                                                   patreonUrl: settings.patreonUrl,
                                                   mastodonUrl: settings.mastodonUrl,
                                                   totalCost: settings.totalCost,
@@ -643,6 +644,13 @@ struct SettingsController {
             if settingsDto.showNews != settings.getBool(.showNews) {
                 try await self.update(.showNews,
                                       with: .boolean(settingsDto.showNews),
+                                      on: request,
+                                      transaction: database)
+            }
+            
+            if settingsDto.showSharedBusinessCards != settings.getBool(.showSharedBusinessCards) {
+                try await self.update(.showSharedBusinessCards,
+                                      with: .boolean(settingsDto.showSharedBusinessCards),
                                       on: request,
                                       transaction: database)
             }

--- a/Sources/VernissageServer/Controllers/SharedBusinessCardsController.swift
+++ b/Sources/VernissageServer/Controllers/SharedBusinessCardsController.swift
@@ -1,0 +1,847 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+import Fluent
+import ActivityPubKit
+
+extension SharedBusinessCardsController: RouteCollection {
+    
+    @_documentation(visibility: private)
+    static let uri: PathComponent = .constant("shared-business-cards")
+    
+    func boot(routes: RoutesBuilder) throws {
+        let sharedBusinessCardsGroup = routes
+            .grouped("api")
+            .grouped("v1")
+            .grouped(SharedBusinessCardsController.uri)
+            .grouped(UserAuthenticator())
+        
+        sharedBusinessCardsGroup
+            .grouped(UserPayload.guardMiddleware())
+            .grouped(EventHandlerMiddleware(.sharedBusinessCardList))
+            .grouped(CacheControlMiddleware(.noStore))
+            .get(use: list)
+        
+        sharedBusinessCardsGroup
+            .grouped(UserPayload.guardMiddleware())
+            .grouped(EventHandlerMiddleware(.sharedBusinessCardRead))
+            .grouped(CacheControlMiddleware(.noStore))
+            .get(":id", use: read)
+        
+        sharedBusinessCardsGroup
+            .grouped(UserPayload.guardMiddleware())
+            .grouped(XsrfTokenValidatorMiddleware())
+            .grouped(EventHandlerMiddleware(.sharedBusinessCardCreate))
+            .grouped(CacheControlMiddleware(.noStore))
+            .post(use: create)
+        
+        sharedBusinessCardsGroup
+            .grouped(UserPayload.guardMiddleware())
+            .grouped(XsrfTokenValidatorMiddleware())
+            .grouped(EventHandlerMiddleware(.sharedBusinessCardUpdate))
+            .grouped(CacheControlMiddleware(.noStore))
+            .put(":id", use: update)
+        
+        sharedBusinessCardsGroup
+            .grouped(UserPayload.guardMiddleware())
+            .grouped(XsrfTokenValidatorMiddleware())
+            .grouped(EventHandlerMiddleware(.sharedBusinessCardDelete))
+            .grouped(CacheControlMiddleware(.noStore))
+            .delete(":id", use: delete)
+        
+        sharedBusinessCardsGroup
+            .grouped(UserPayload.guardMiddleware())
+            .grouped(XsrfTokenValidatorMiddleware())
+            .grouped(EventHandlerMiddleware(.sharedBusinessCardMessage))
+            .grouped(CacheControlMiddleware(.noStore))
+            .post(":id", "message", use: message)
+        
+        sharedBusinessCardsGroup
+            .grouped(UserPayload.guardMiddleware())
+            .grouped(XsrfTokenValidatorMiddleware())
+            .grouped(EventHandlerMiddleware(.sharedBusinessCardRevoke))
+            .grouped(CacheControlMiddleware(.noStore))
+            .post(":id", "revoke", use: revoke)
+
+        sharedBusinessCardsGroup
+            .grouped(UserPayload.guardMiddleware())
+            .grouped(XsrfTokenValidatorMiddleware())
+            .grouped(EventHandlerMiddleware(.sharedBusinessCardUnrevoke))
+            .grouped(CacheControlMiddleware(.noStore))
+            .post(":id", "unrevoke", use: unrevoke)
+        
+        sharedBusinessCardsGroup
+            .grouped(EventHandlerMiddleware(.sharedBusinessCardReadByThirdParty))
+            .grouped(CacheControlMiddleware(.noStore))
+            .get(":id", "third-party", use: readByThirdParty)
+                
+        sharedBusinessCardsGroup
+            .grouped(EventHandlerMiddleware(.sharedBusinessCardUpdateByThirdParty))
+            .grouped(CacheControlMiddleware(.noStore))
+            .put(":id", "third-party", use: updateByThirdParty)
+        
+        sharedBusinessCardsGroup
+            .grouped(EventHandlerMiddleware(.sharedBusinessCardMessageByThirdParty))
+            .grouped(CacheControlMiddleware(.noStore))
+            .post(":id", "third-party", "message", use: messageByThirdParty)
+    }
+}
+
+/// Exposing shared business card logic.
+///
+/// Endpoint is responsible for all business logic regarding shared business cards.
+///
+/// > Important: Base controller URL: `/api/v1/shared-business-cards`.
+struct SharedBusinessCardsController {
+    
+    /// Exposing list of shared business cards.
+    ///
+    /// The endpoint returns list of shared business cards with paginable functionality.
+    ///
+    /// Optional query params:
+    /// - `page` - number of page to return
+    /// - `size` - limit amount of returned entities on one page (default: 10)
+    ///
+    /// > Important: Endpoint URL: `/api/v1/shared-business-cards`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/shared-business-cards" \
+    /// -X GET \
+    /// -H "Content-Type: application/json" \
+    /// -H "Authorization: Bearer [ACCESS_TOKEN]" \
+    /// ```
+    ///
+    /// **Example response body:**
+    ///
+    /// ```json
+    /// {
+    ///     "data": [
+    ///         {
+    ///             "code": "9nBFMtpvUm6vBcQCUQLNsIVoy7WtPxwRxqb5UTw3oseWIuIu6yeBbM53qE1dR7xh",
+    ///             "createdAt": "2025-04-28T19:15:55.240Z",
+    ///             "id": "7498444910865942753",
+    ///             "note": "Photos taken near the bridge",
+    ///             "revokedAt": "2025-04-28T19:16:54.140Z",
+    ///             "thirdPartyEmail": "johmdoe@example.com",
+    ///             "thirdPartyName": "Marcin111",
+    ///             "title": "The bridge portraits",
+    ///             "updatedAt": "2025-04-28T19:16:54.141Z"
+    ///         },
+    ///         {
+    ///             "code": "fWP0kDKZCA7x8SRmBgaqlK6g51ulprP2zhQ97DhuFwpsjYqrLShnPtweMtZ6gKe7",
+    ///             "createdAt": "2025-04-28T11:49:40.000Z",
+    ///             "id": "7498329908821625471",
+    ///             "note": "Two ladies with dog near the cathedral",
+    ///             "revokedAt": "2025-04-28T19:16:54.504Z",
+    ///             "thirdPartyEmail": "anna.doe@example.com",
+    ///             "thirdPartyName": "Anna Maria Jopek",
+    ///             "title": "Cathedar ladies",
+    ///             "updatedAt": "2025-04-28T19:16:54.504Z"
+    ///          }
+    ///     ],
+    ///     "page": 1,
+    ///     "size": 10,
+    ///     "total": 2
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    ///
+    /// - Returns: List of paginable shared business cards.
+    @Sendable
+    func list(request: Request) async throws -> PaginableResultDto<SharedBusinessCardDto> {
+        guard let authorizationPayloadId = request.userId else {
+            throw Abort(.forbidden)
+        }
+
+        let page: Int = request.query["page"] ?? 0
+        let size: Int = request.query["size"] ?? 10
+
+        let sharedBusinessCardsFromDatabase = try await SharedBusinessCard.query(on: request.db)
+            .join(BusinessCard.self, on: \SharedBusinessCard.$businessCard.$id == \BusinessCard.$id)
+            .filter(BusinessCard.self, \.$user.$id == authorizationPayloadId)
+            .sort(\.$createdAt, .descending)
+            .paginate(PageRequest(page: page, per: size))
+
+        let businessCardsService = request.application.services.businessCardsService
+        let sharedBusinessCardsDtos = sharedBusinessCardsFromDatabase.items.map {
+            businessCardsService.convertToDto(sharedBusinessCard: $0, messages: nil, on: request.executionContext)
+        }
+
+        return PaginableResultDto(
+            data: sharedBusinessCardsDtos,
+            page: sharedBusinessCardsFromDatabase.metadata.page,
+            size: sharedBusinessCardsFromDatabase.metadata.per,
+            total: sharedBusinessCardsFromDatabase.metadata.total
+        )
+    }
+    
+    /// Get existing shared business card.
+    ///
+    /// The endpoint can be used for downloading existing shared business card from the system.
+    ///
+    /// > Important: Endpoint URL: `/api/v1/shared-business-cards/:id`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/shared-business-cards/7302167186067544065" \
+    /// -X GET \
+    /// -H "Content-Type: application/json" \
+    /// -H "Authorization: Bearer [ACCESS_TOKEN]"
+    /// ```
+    ///
+    /// **Example response body:**
+    ///
+    /// ```json
+    /// {
+    ///     "code": "9nBFMtpvUm6vBcQCUQLNsIVoy7WtPxwRxqb5UTw3oseWIuIu6yeBbM53qE1dR7xh",
+    ///     "createdAt": "2025-04-28T19:15:55.240Z",
+    ///     "id": "7498444910865942753",
+    ///     "messages": [
+    ///         {
+    ///             "addedByUser": false,
+    ///             "createdAt": "2025-04-28T19:16:28.075Z",
+    ///             "id": "7498445052599863521",
+    ///             "message": "Ala ma kota",
+    ///             "updatedAt": "2025-04-28T19:16:28.075Z"
+    ///         },
+    ///         {
+    ///             "addedByUser": true,
+    ///             "createdAt": "2025-04-28T19:16:36.168Z",
+    ///             "id": "7498445086959601889",
+    ///             "message": "Ale",
+    ///             "updatedAt": "2025-04-28T19:16:36.168Z"
+    ///         }
+    ///     ],
+    ///     "note": "This is note for card",
+    ///     "revokedAt": "2025-04-28T19:16:54.140Z",
+    ///     "thirdPartyEmail": "jdoe@example.com",
+    ///     "thirdPartyName": "Joanna Doe",
+    ///     "title": "The title",
+    ///     "updatedAt": "2025-04-28T19:16:54.141Z"
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    ///
+    /// - Returns: Entity data.
+    @Sendable
+    func read(request: Request) async throws -> SharedBusinessCardDto {
+        guard let authorizationPayloadId = request.userId else {
+            throw Abort(.forbidden)
+        }
+        
+        guard let sharedBusinessCardIdString = request.parameters.get("id", as: String.self) else {
+            throw SharedBusinessCardError.incorrectSharedBusinessCardId
+        }
+        
+        guard let sharedBusinessCardId = sharedBusinessCardIdString.toId() else {
+            throw SharedBusinessCardError.incorrectSharedBusinessCardId
+        }
+        
+        guard let sharedBusinessCardFromDatabase = try await SharedBusinessCard.query(on: request.db)
+            .with(\.$messages)
+            .join(BusinessCard.self, on: \SharedBusinessCard.$businessCard.$id == \BusinessCard.$id)
+            .filter(BusinessCard.self, \.$user.$id == authorizationPayloadId)
+            .filter(\.$id == sharedBusinessCardId)
+            .first() else {
+            throw EntityNotFoundError.sharedBusinessCardNotFound
+        }
+        
+        let businessCardsService = request.application.services.businessCardsService
+        return businessCardsService.convertToDto(sharedBusinessCard: sharedBusinessCardFromDatabase,
+                                                 messages: sharedBusinessCardFromDatabase.messages,
+                                                 on: request.executionContext)
+    }
+    
+    /// Create new shared business card.
+    ///
+    /// The endpoint can be used for creating new shared business card in the system.
+    ///
+    /// > Important: Endpoint URL: `/api/v1/shared-business-cards`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/shared-business-cards" \
+    /// -X POST \
+    /// -H "Content-Type: application/json" \
+    /// -H "Authorization: Bearer [ACCESS_TOKEN]" \
+    /// -d '{ ... }'
+    /// ```
+    ///
+    /// **Example request body:**
+    ///
+    /// ```json
+    /// {
+    ///     "title": "The title",
+    ///     "note": "This is note for card",
+    /// }
+    /// ```
+    ///
+    /// **Example response body:**
+    ///
+    /// ```json
+    /// {
+    ///     "code": "9nBFMtpvUm6vBcQCUQLNsIVoy7WtPxwRxqb5UTw3oseWIuIu6yeBbM53qE1dR7xh",
+    ///     "createdAt": "2025-04-28T19:15:55.240Z",
+    ///     "id": "7498444910865942753",
+    ///     "note": "This is note for card",
+    ///     "thirdPartyEmail": "",
+    ///     "thirdPartyName": "",
+    ///     "title": "The title",
+    ///     "updatedAt": "2025-04-28T19:16:54.141Z"
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    ///
+    /// - Returns: New added entity.
+    @Sendable
+    func create(request: Request) async throws -> Response {
+        guard let authorizationPayloadId = request.userId else {
+            throw Abort(.forbidden)
+        }
+        
+        let sharedBusinessCardDto = try request.content.decode(SharedBusinessCardDto.self)
+        try SharedBusinessCardDto.validate(content: request)
+                        
+        guard let businessCardFromDatabase = try await BusinessCard.query(on: request.db)
+            .filter(\.$user.$id == authorizationPayloadId)
+            .first() else {
+            throw EntityNotFoundError.businessCardNotFound
+        }
+        
+        let newSharedBusinessCardId = request.application.services.snowflakeService.generate()
+        let code = String.createRandomString(length: 64)
+        
+        let sharedBusinessCard = try SharedBusinessCard(id: newSharedBusinessCardId,
+                                                        businessCardId: businessCardFromDatabase.requireID(),
+                                                        code: code,
+                                                        title: sharedBusinessCardDto.title,
+                                                        note: sharedBusinessCardDto.note,
+                                                        thirdPartyName: sharedBusinessCardDto.thirdPartyName ?? "",
+                                                        thirdPartyEmail: sharedBusinessCardDto.thirdPartyEmail)
+        
+        try await sharedBusinessCard.save(on: request.db)
+        
+        guard let sharedBusinessCardFromDatabase = try await SharedBusinessCard.query(on: request.db)
+            .with(\.$messages)
+            .filter(\.$id == newSharedBusinessCardId)
+            .first() else {
+            throw EntityNotFoundError.sharedBusinessCardNotFound
+        }
+        
+        return try await createSharedBusinessCardResponse(on: request, sharedBusinessCard: sharedBusinessCardFromDatabase)
+    }
+    
+    /// Update existing shared business card.
+    ///
+    /// The endpoint can be used for updating existing shared business card in the system.
+    ///
+    /// > Important: Endpoint URL: `/api/v1/shared-business-cards/:id`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/shared-business-cards/7302167186067544065" \
+    /// -X POST \
+    /// -H "Content-Type: application/json" \
+    /// -H "Authorization: Bearer [ACCESS_TOKEN]" \
+    /// -d '{ ... }'
+    /// ```
+    ///
+    /// **Example request body:**
+    ///
+    /// ```json
+    /// {
+    ///     "id": "7498444910865942753",
+    ///     "title": "New abstract title",
+    ///     "note": "This is note for card"
+    /// }
+    /// ```
+    ///
+    /// **Example response body:**
+    ///
+    /// ```json
+    /// {
+    ///     "code": "9nBFMtpvUm6vBcQCUQLNsIVoy7WtPxwRxqb5UTw3oseWIuIu6yeBbM53qE1dR7xh",
+    ///     "createdAt": "2025-04-28T19:15:55.240Z",
+    ///     "id": "7498444910865942753",
+    ///     "note": "This is note for card",
+    ///     "thirdPartyEmail": "",
+    ///     "thirdPartyName": "",
+    ///     "title": "New abstract title",
+    ///     "updatedAt": "2025-04-28T19:16:54.141Z"
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    ///
+    /// - Returns: Updated entity.
+    @Sendable
+    func update(request: Request) async throws -> SharedBusinessCardDto {
+        let sharedBusinessCardDto = try request.content.decode(SharedBusinessCardDto.self)
+        try SharedBusinessCardDto.validate(content: request)
+        
+        guard let authorizationPayloadId = request.userId else {
+            throw Abort(.forbidden)
+        }
+        
+        guard let sharedBusinessCardIdString = request.parameters.get("id", as: String.self) else {
+            throw SharedBusinessCardError.incorrectSharedBusinessCardId
+        }
+        
+        guard let sharedBusinessCardId = sharedBusinessCardIdString.toId() else {
+            throw SharedBusinessCardError.incorrectSharedBusinessCardId
+        }
+        
+        guard let sharedBusinessCardFromDatabase = try await SharedBusinessCard.query(on: request.db)
+            .with(\.$messages)
+            .join(BusinessCard.self, on: \SharedBusinessCard.$businessCard.$id == \BusinessCard.$id)
+            .filter(BusinessCard.self, \.$user.$id == authorizationPayloadId)
+            .filter(\.$id == sharedBusinessCardId)
+            .first() else {
+            throw EntityNotFoundError.sharedBusinessCardNotFound
+        }
+        
+        sharedBusinessCardFromDatabase.title = sharedBusinessCardDto.title
+        sharedBusinessCardFromDatabase.note = sharedBusinessCardDto.note
+        sharedBusinessCardFromDatabase.thirdPartyName = sharedBusinessCardDto.thirdPartyName ?? ""
+        sharedBusinessCardFromDatabase.thirdPartyEmail = sharedBusinessCardDto.thirdPartyEmail
+
+        try await sharedBusinessCardFromDatabase.save(on: request.db)
+
+        let businessCardsService = request.application.services.businessCardsService
+        return businessCardsService.convertToDto(sharedBusinessCard: sharedBusinessCardFromDatabase,
+                                                 messages: sharedBusinessCardFromDatabase.messages,
+                                                 on: request.executionContext)
+    }
+    
+    /// Delete shared business card from the database.
+    ///
+    /// The endpoint can be used for deleting existing shared business card.
+    ///
+    /// > Important: Endpoint URL: `/api/v1/shared-business-cards/:id`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/shared-business-cards/7267938074834522113" \
+    /// -X DELETE \
+    /// -H "Content-Type: application/json" \
+    /// -H "Authorization: Bearer [ACCESS_TOKEN]"
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    ///
+    /// - Returns: Http status code.
+    @Sendable
+    func delete(request: Request) async throws -> HTTPStatus {
+        guard let authorizationPayloadId = request.userId else {
+            throw Abort(.forbidden)
+        }
+        
+        guard let sharedBusinessCardIdString = request.parameters.get("id", as: String.self) else {
+            throw SharedBusinessCardError.incorrectSharedBusinessCardId
+        }
+        
+        guard let sharedBusinessCardId = sharedBusinessCardIdString.toId() else {
+            throw SharedBusinessCardError.incorrectSharedBusinessCardId
+        }
+        
+        guard let sharedBusinessCardFromDatabase = try await SharedBusinessCard.query(on: request.db)
+            .with(\.$messages)
+            .join(BusinessCard.self, on: \SharedBusinessCard.$businessCard.$id == \BusinessCard.$id)
+            .filter(BusinessCard.self, \.$user.$id == authorizationPayloadId)
+            .filter(\.$id == sharedBusinessCardId)
+            .first() else {
+            throw EntityNotFoundError.sharedBusinessCardNotFound
+        }
+
+        // Datelete shared business card with all messages added to it.
+        try await request.db.transaction { database in
+            for message in sharedBusinessCardFromDatabase.messages {
+                try await message.delete(on: database)
+            }
+            
+            try await sharedBusinessCardFromDatabase.delete(on: database)
+        }
+        
+        return HTTPStatus.ok
+    }
+    
+    /// Add new message to shared business card by the owner.
+    ///
+    /// The endpoint can be used for adding new messages to the shared business card by his owner.
+    ///
+    /// > Important: Endpoint URL: `/api/v1/shared-business-cards/:id/message`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/shared-business-cards/7302167186067544065/message" \
+    /// -X GET \
+    /// -H "Content-Type: application/json" \
+    /// -H "Authorization: Bearer [ACCESS_TOKEN]" \
+    /// -d '{ ... }'
+    /// ```
+    ///
+    /// **Example request body:**
+    ///
+    /// ```json
+    /// {
+    ///     "message": "Hello. I'm your photographer!"
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    @Sendable
+    func message(request: Request) async throws -> HTTPStatus {
+        guard let authorizationPayloadId = request.userId else {
+            throw Abort(.forbidden)
+        }
+        
+        let sharedBusinessCardMessageDto = try request.content.decode(SharedBusinessCardMessageDto.self)
+        try SharedBusinessCardMessageDto.validate(content: request)
+        
+        guard let sharedBusinessCardIdString = request.parameters.get("id", as: String.self) else {
+            throw SharedBusinessCardError.incorrectSharedBusinessCardId
+        }
+        
+        guard let sharedBusinessCardId = sharedBusinessCardIdString.toId() else {
+            throw SharedBusinessCardError.incorrectSharedBusinessCardId
+        }
+        
+        guard let sharedBusinessCardFromDatabase = try await SharedBusinessCard.query(on: request.db)
+            .join(BusinessCard.self, on: \SharedBusinessCard.$businessCard.$id == \BusinessCard.$id)
+            .filter(BusinessCard.self, \.$user.$id == authorizationPayloadId)
+            .filter(\.$id == sharedBusinessCardId)
+            .first() else {
+            throw EntityNotFoundError.sharedBusinessCardNotFound
+        }
+        
+        let newSharedBusinessCardMessageId = request.application.services.snowflakeService.generate()
+        let sharedBusinessCardMessage = try SharedBusinessCardMessage(id: newSharedBusinessCardMessageId,
+                                                                      sharedBusinessCardId: sharedBusinessCardFromDatabase.requireID(),
+                                                                      userId: authorizationPayloadId,
+                                                                      message: sharedBusinessCardMessageDto.message)
+
+        try await sharedBusinessCardMessage.save(on: request.db)
+        
+        return HTTPStatus.ok
+    }
+    
+    /// Revoke shared business card.
+    ///
+    /// The endpoint can be used for revoking access by third party to the shared business card.
+    ///
+    /// > Important: Endpoint URL: `/api/v1/shared-business-cards/:id/revoke`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/shared-business-cards/7302167186067544065/revoke" \
+    /// -X GET \
+    /// -H "Content-Type: application/json" \
+    /// -H "Authorization: Bearer [ACCESS_TOKEN]"
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    @Sendable
+    func revoke(request: Request) async throws -> HTTPStatus {
+        guard let authorizationPayloadId = request.userId else {
+            throw Abort(.forbidden)
+        }
+        
+        guard let sharedBusinessCardIdString = request.parameters.get("id", as: String.self) else {
+            throw SharedBusinessCardError.incorrectSharedBusinessCardId
+        }
+        
+        guard let sharedBusinessCardId = sharedBusinessCardIdString.toId() else {
+            throw SharedBusinessCardError.incorrectSharedBusinessCardId
+        }
+        
+        guard let sharedBusinessCardFromDatabase = try await SharedBusinessCard.query(on: request.db)
+            .join(BusinessCard.self, on: \SharedBusinessCard.$businessCard.$id == \BusinessCard.$id)
+            .filter(BusinessCard.self, \.$user.$id == authorizationPayloadId)
+            .filter(\.$id == sharedBusinessCardId)
+            .first() else {
+            throw EntityNotFoundError.sharedBusinessCardNotFound
+        }
+        
+        sharedBusinessCardFromDatabase.revokedAt = Date()
+        try await sharedBusinessCardFromDatabase.save(on: request.db)
+        
+        return HTTPStatus.ok
+    }
+    
+    /// Unrevoke shared business card.
+    ///
+    /// The endpoint can be used for allowing access by third party to the shared business card.
+    ///
+    /// > Important: Endpoint URL: `/api/v1/shared-business-cards/:id/unrevoke`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/shared-business-cards/7302167186067544065/unrevoke" \
+    /// -X GET \
+    /// -H "Content-Type: application/json" \
+    /// -H "Authorization: Bearer [ACCESS_TOKEN]"
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    @Sendable
+    func unrevoke(request: Request) async throws -> HTTPStatus {
+        guard let authorizationPayloadId = request.userId else {
+            throw Abort(.forbidden)
+        }
+        
+        guard let sharedBusinessCardIdString = request.parameters.get("id", as: String.self) else {
+            throw SharedBusinessCardError.incorrectSharedBusinessCardId
+        }
+        
+        guard let sharedBusinessCardId = sharedBusinessCardIdString.toId() else {
+            throw SharedBusinessCardError.incorrectSharedBusinessCardId
+        }
+        
+        guard let sharedBusinessCardFromDatabase = try await SharedBusinessCard.query(on: request.db)
+            .join(BusinessCard.self, on: \SharedBusinessCard.$businessCard.$id == \BusinessCard.$id)
+            .filter(BusinessCard.self, \.$user.$id == authorizationPayloadId)
+            .filter(\.$id == sharedBusinessCardId)
+            .first() else {
+            throw EntityNotFoundError.sharedBusinessCardNotFound
+        }
+        
+        sharedBusinessCardFromDatabase.revokedAt = nil
+        try await sharedBusinessCardFromDatabase.save(on: request.db)
+        
+        return HTTPStatus.ok
+    }
+    
+    /// Get existing shared business card based on generated code.
+    ///
+    /// The endpoint can be used for downloading existing shared business card from the system.
+    /// Shared business card is downloaded by code (by third party).
+    ///
+    /// > Important: Endpoint URL: `/api/v1/shared-business-cards/:code/third-party`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/shared-business-cards/dfg8fg8aa6sdgt8bcxsdfas7tsafgh98gs8/third-party" \
+    /// -X GET \
+    /// -H "Content-Type: application/json" \
+    /// -d '{ ... }'
+    /// ```
+    ///
+    /// **Example response body:**
+    ///
+    /// ```json
+    /// {
+    ///     "code": "9nBFMtpvUm6vBcQCUQLNsIVoy7WtPxwRxqb5UTw3oseWIuIu6yeBbM53qE1dR7xh",
+    ///     "createdAt": "2025-04-28T19:15:55.240Z",
+    ///     "id": "7498444910865942753",
+    ///     "messages": [
+    ///         {
+    ///             "addedByUser": false,
+    ///             "createdAt": "2025-04-28T19:16:28.075Z",
+    ///             "id": "7498445052599863521",
+    ///             "message": "Ala ma kota",
+    ///             "updatedAt": "2025-04-28T19:16:28.075Z"
+    ///         },
+    ///         {
+    ///             "addedByUser": true,
+    ///             "createdAt": "2025-04-28T19:16:36.168Z",
+    ///             "id": "7498445086959601889",
+    ///             "message": "Ale",
+    ///             "updatedAt": "2025-04-28T19:16:36.168Z"
+    ///         }
+    ///     ],
+    ///     "note": "",
+    ///     "revokedAt": "2025-04-28T19:16:54.140Z",
+    ///     "thirdPartyEmail": "jdoe@example.com",
+    ///     "thirdPartyName": "Joanna Doe",
+    ///     "title": "",
+    ///     "updatedAt": "2025-04-28T19:16:54.141Z"
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    ///
+    /// - Returns: Entity data.
+    @Sendable
+    func readByThirdParty(request: Request) async throws -> SharedBusinessCardDto {
+        guard let sharedBusinessCardCode = request.parameters.get("id", as: String.self) else {
+            throw SharedBusinessCardError.incorrectCode
+        }
+                
+        guard let sharedBusinessCardFromDatabase = try await SharedBusinessCard.query(on: request.db)
+            .with(\.$messages)
+            .filter(\.$code == sharedBusinessCardCode)
+            .filter(\.$revokedAt == nil)
+            .first() else {
+            throw EntityNotFoundError.sharedBusinessCardNotFound
+        }
+        
+        guard let businessCardFromDatabase = try await BusinessCard.query(on: request.db)
+            .with(\.$user)
+            .with(\.$businessCardFields)
+            .filter(\.$id == sharedBusinessCardFromDatabase.$businessCard.id)
+            .first() else {
+            throw EntityNotFoundError.businessCardNotFound
+        }
+        
+        let businessCardsService = request.application.services.businessCardsService
+        return businessCardsService.convertToDto(sharedBusinessCard: sharedBusinessCardFromDatabase,
+                                                 with: businessCardFromDatabase,
+                                                 clearSensitive: true,
+                                                 on: request.executionContext)
+    }
+    
+    /// Update existing shared business card based on generated code.
+    ///
+    /// The endpoint can be used for updating existing shared business card in the system.
+    /// Shared business card is updated by code (by third party).
+    ///
+    /// > Important: Endpoint URL: `/api/v1/shared-business-cards/:code/third-party`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/shared-business-cards/dfg8fg8aa6sdgt8bcxsdfas7tsafgh98gs8/third-party" \
+    /// -X PUT \
+    /// -H "Content-Type: application/json" \
+    /// -d '{ ... }'
+    /// ```
+    ///
+    /// **Example response body:**
+    ///
+    /// ```json
+    /// {
+    ///     "sharedCardUrl": "http://vernissage.com/codes/544grasgw454asdgf",
+    ///     "thirdPartyEmail": "jdoe@example.com",
+    ///     "thirdPartyName": "Joanna Doe"
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    ///
+    /// - Returns: Http status code.
+    @Sendable
+    func updateByThirdParty(request: Request) async throws -> HTTPStatus {
+        let sharedBusinessCardUpdateRequestDto = try request.content.decode(SharedBusinessCardUpdateRequestDto.self)
+        try SharedBusinessCardUpdateRequestDto.validate(content: request)
+
+        guard let sharedBusinessCardCode = request.parameters.get("id", as: String.self) else {
+            throw SharedBusinessCardError.incorrectCode
+        }
+                
+        guard let sharedBusinessCardFromDatabase = try await SharedBusinessCard.query(on: request.db)
+            .with(\.$messages)
+            .filter(\.$code == sharedBusinessCardCode)
+            .filter(\.$revokedAt == nil)
+            .first() else {
+            throw EntityNotFoundError.sharedBusinessCardNotFound
+        }
+        
+        sharedBusinessCardFromDatabase.thirdPartyName = sharedBusinessCardUpdateRequestDto.thirdPartyName ?? ""
+        sharedBusinessCardFromDatabase.thirdPartyEmail = sharedBusinessCardUpdateRequestDto.thirdPartyEmail
+        
+        try await sharedBusinessCardFromDatabase.update(on: request.db)
+        
+        // If email is specified we can send email with url to shared card.
+        if sharedBusinessCardFromDatabase.thirdPartyEmail != nil && sharedBusinessCardFromDatabase.thirdPartyEmail?.isEmpty == false {
+            let emailsService = request.application.services.emailsService
+            try await emailsService.dispatchSharedBusinessCardEmail(sharedBusinessCard: sharedBusinessCardFromDatabase,
+                                                                    sharedCardUrl: sharedBusinessCardUpdateRequestDto.sharedCardUrl,
+                                                                    on: request.executionContext)
+        }
+        
+        return HTTPStatus.ok
+    }
+    
+    /// Add to shared business card message by third party. (code)
+    ///
+    /// The endpoint can be used for adding new message to the shared business card by third party.
+    ///
+    /// > Important: Endpoint URL: `/api/v1/shared-business-cards/:code/third-party/message`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/shared-business-cards/dfg8fg8aa6sdgt8bcxsdfas7tsafgh98gs8/third-party/message" \
+    /// -X GET \
+    /// -H "Content-Type: application/json" \
+    /// -d '{ ... }'
+    /// ```
+    ///
+    /// **Example response body:**
+    ///
+    /// ```json
+    /// {
+    ///     "message": "Hello. I'm your photographer!"
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    ///
+    /// - Returns: Http status code.
+    @Sendable
+    func messageByThirdParty(request: Request) async throws -> HTTPStatus {
+        let sharedBusinessCardMessageDto = try request.content.decode(SharedBusinessCardMessageDto.self)
+        try SharedBusinessCardMessageDto.validate(content: request)
+
+        guard let sharedBusinessCardCode = request.parameters.get("id", as: String.self) else {
+            throw SharedBusinessCardError.incorrectCode
+        }
+                
+        guard let sharedBusinessCardFromDatabase = try await SharedBusinessCard.query(on: request.db)
+            .with(\.$messages)
+            .filter(\.$code == sharedBusinessCardCode)
+            .filter(\.$revokedAt == nil)
+            .first() else {
+            throw EntityNotFoundError.sharedBusinessCardNotFound
+        }
+        
+        let newSharedBusinessCardMessageId = request.application.services.snowflakeService.generate()
+        let sharedBusinessCardMessage = try SharedBusinessCardMessage(id: newSharedBusinessCardMessageId,
+                                      sharedBusinessCardId: sharedBusinessCardFromDatabase.requireID(),
+                                      message: sharedBusinessCardMessageDto.message)
+        
+        try await sharedBusinessCardMessage.save(on: request.db)
+        
+        return HTTPStatus.ok
+    }
+    
+    private func createSharedBusinessCardResponse(on request: Request, sharedBusinessCard: SharedBusinessCard) async throws -> Response {
+        let businessCardsService = request.application.services.businessCardsService
+        let sharedBusinessCardDto = businessCardsService.convertToDto(sharedBusinessCard: sharedBusinessCard,
+                                                                      messages: nil,
+                                                                      on: request.executionContext)
+        
+        var headers = HTTPHeaders()
+        headers.replaceOrAdd(name: .location, value: "/\(SharedBusinessCardsController.uri)/@\(sharedBusinessCard.stringId() ?? "")")
+        
+        return try await sharedBusinessCardDto.encodeResponse(status: .created, headers: headers, for: request)
+    }
+}

--- a/Sources/VernissageServer/DataTransferObjects/BusinessCardDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/BusinessCardDto.swift
@@ -1,0 +1,58 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+
+struct BusinessCardDto {
+    var id: String?
+    var user: UserDto?
+    var title: String
+    var subtitle: String?
+    var body: String?
+    var website: String?
+    var telephone: String?
+    var email: String?
+    var color1: String
+    var color2: String
+    var color3: String
+    var createdAt: Date?
+    var updatedAt: Date?
+    var fields: [BusinessCardFieldDto]?
+}
+
+extension BusinessCardDto {
+    init(from businessCard: BusinessCard, baseAddress: String, baseImagesPath: String) {
+        self.init(id: businessCard.stringId(),
+                  user: UserDto(from: businessCard.user, baseImagesPath: baseImagesPath, baseAddress: baseAddress),
+                  title: businessCard.title,
+                  subtitle: businessCard.subtitle,
+                  body: businessCard.body,
+                  website: businessCard.website,
+                  telephone: businessCard.telephone,
+                  email: businessCard.email,
+                  color1: businessCard.color1,
+                  color2: businessCard.color2,
+                  color3: businessCard.color3,
+                  createdAt: businessCard.createdAt,
+                  updatedAt: businessCard.updatedAt,
+                  fields: businessCard.businessCardFields.map { BusinessCardFieldDto(from: $0) })
+    }
+}
+
+extension BusinessCardDto: Content { }
+
+extension BusinessCardDto: Validatable {
+    static func validations(_ validations: inout Validations) {
+        validations.add("title", as: String.self, is: .count(1...200), required: true)
+        validations.add("subtitle", as: String?.self, is: .count(...500) || .nil, required: false)
+        validations.add("website", as: String?.self, is: .count(...500) || .nil, required: false)
+        validations.add("telephone", as: String?.self, is: .count(...50) || .nil, required: false)
+        validations.add("email", as: String?.self, is: .count(...500) || .nil, required: false)
+        validations.add("color1", as: String.self, is: .count(1...50), required: true)
+        validations.add("color2", as: String.self, is: .count(1...50), required: true)
+        validations.add("color3", as: String.self, is: .count(1...50), required: true)
+    }
+}

--- a/Sources/VernissageServer/DataTransferObjects/BusinessCardFieldDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/BusinessCardFieldDto.swift
@@ -1,0 +1,34 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+
+struct BusinessCardFieldDto {
+    var id: String?
+    var key: String
+    var value: String
+    var createdAt: Date?
+    var updatedAt: Date?
+}
+
+extension BusinessCardFieldDto {
+    init(from businessCardField: BusinessCardField) {
+        self.init(id: businessCardField.stringId(),
+                  key: businessCardField.key,
+                  value: businessCardField.value,
+                  createdAt: businessCardField.createdAt,
+                  updatedAt: businessCardField.updatedAt)
+    }
+}
+
+extension BusinessCardFieldDto: Content { }
+
+extension BusinessCardFieldDto: Validatable {
+    static func validations(_ validations: inout Validations) {
+        validations.add("key", as: String.self, is: .count(1...200), required: true)
+        validations.add("value", as: String.self, is: .count(1...500), required: true)
+    }
+}

--- a/Sources/VernissageServer/DataTransferObjects/PublicSettingsDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/PublicSettingsDto.swift
@@ -12,6 +12,7 @@ struct PublicSettingsDto {
     var webPushVapidPublicKey: String?
     var imagesUrl: String?
     var showNews: Bool
+    var showSharedBusinessCards: Bool
 
     var patreonUrl: String?
     var mastodonUrl: String?

--- a/Sources/VernissageServer/DataTransferObjects/SettingsDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/SettingsDto.swift
@@ -34,6 +34,7 @@ struct SettingsDto {
     var statusPurgeAfterDays: Int
     var imagesUrl: String
     var showNews: Bool
+    var showSharedBusinessCards: Bool
     
     var maxCharacters: Int
     var maxMediaAttachments: Int
@@ -113,6 +114,7 @@ struct SettingsDto {
         self.statusPurgeAfterDays = settings.getInt(.statusPurgeAfterDays) ?? 180
         self.imagesUrl = settings.getString(.imagesUrl) ?? ""
         self.showNews = settings.getBool(.showNews) ?? false
+        self.showSharedBusinessCards = settings.getBool(.showSharedBusinessCards) ?? false
         
         self.isOpenAIEnabled = settings.getBool(.isOpenAIEnabled) ?? false
         self.openAIKey = settings.getString(.openAIKey) ?? ""

--- a/Sources/VernissageServer/DataTransferObjects/SharedBusinessCardDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/SharedBusinessCardDto.swift
@@ -1,0 +1,57 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+
+struct SharedBusinessCardDto {
+    var id: String?
+    var businessCardId: String?
+    var businessCard: BusinessCardDto?
+    var code: String?
+    var title: String
+    var note: String?
+    var thirdPartyName: String?
+    var thirdPartyEmail: String?
+    var revokedAt: Date?
+    var createdAt: Date?
+    var updatedAt: Date?
+    
+    var messages: [SharedBusinessCardMessageDto]?
+}
+
+extension SharedBusinessCardDto {
+    init(from sharedBusinessCard: SharedBusinessCard,
+         messages: [SharedBusinessCardMessage]? = nil,
+         businessCardDto: BusinessCardDto? = nil,
+         baseAddress: String,
+         baseImagesPath: String
+    ) {
+        self.init(id: sharedBusinessCard.stringId(),
+                  businessCardId: businessCardDto?.id,
+                  businessCard: businessCardDto,
+                  code: sharedBusinessCard.code,
+                  title: sharedBusinessCard.title,
+                  note: sharedBusinessCard.note,
+                  thirdPartyName: sharedBusinessCard.thirdPartyName,
+                  thirdPartyEmail: sharedBusinessCard.thirdPartyEmail,
+                  revokedAt: sharedBusinessCard.revokedAt,
+                  createdAt: sharedBusinessCard.createdAt,
+                  updatedAt: sharedBusinessCard.updatedAt,
+                  messages: messages?.map { SharedBusinessCardMessageDto(from: $0, baseAddress: baseAddress, baseImagesPath: baseImagesPath) })
+    }
+}
+
+extension SharedBusinessCardDto: Content { }
+
+extension SharedBusinessCardDto: Validatable {
+    static func validations(_ validations: inout Validations) {
+        validations.add("code", as: String?.self, is: .count(...64) || .nil, required: false)
+        validations.add("title", as: String.self, is: .count(1...200), required: true)
+        validations.add("note", as: String?.self, is: .count(...500) || .nil, required: false)
+        validations.add("thirdPartyName", as: String?.self, is: .count(...100) || .nil, required: false)
+        validations.add("thirdPartyEmail", as: String?.self, is: .email || .nil, required: false)
+    }
+}

--- a/Sources/VernissageServer/DataTransferObjects/SharedBusinessCardMessageDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/SharedBusinessCardMessageDto.swift
@@ -1,0 +1,38 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+
+struct SharedBusinessCardMessageDto {
+    var id: String?
+    var addedByUser: Bool?
+    var message: String
+    var createdAt: Date?
+    var updatedAt: Date?
+}
+
+extension SharedBusinessCardMessageDto {
+    init(from sharedBusinessCardMessage: SharedBusinessCardMessage, baseAddress: String, baseImagesPath: String) {
+        var addedByUser = false
+        if sharedBusinessCardMessage.$user.id != nil {
+            addedByUser = true
+        }
+        
+        self.init(id: sharedBusinessCardMessage.stringId(),
+                  addedByUser: addedByUser,
+                  message: sharedBusinessCardMessage.message,
+                  createdAt: sharedBusinessCardMessage.createdAt,
+                  updatedAt: sharedBusinessCardMessage.updatedAt)
+    }
+}
+
+extension SharedBusinessCardMessageDto: Content { }
+
+extension SharedBusinessCardMessageDto: Validatable {
+    static func validations(_ validations: inout Validations) {
+        validations.add("message", as: String.self, is: .count(1...500), required: true)
+    }
+}

--- a/Sources/VernissageServer/DataTransferObjects/SharedBusinessCardUpdateRequestDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/SharedBusinessCardUpdateRequestDto.swift
@@ -1,0 +1,28 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+
+struct SharedBusinessCardUpdateRequestDto {
+    /// Third party name.
+    var thirdPartyName: String?
+    
+    /// Third party email.
+    var thirdPartyEmail: String?
+    
+    /// Base url to web application. It's used to send email with shared card url.
+    var sharedCardUrl: String
+}
+
+extension SharedBusinessCardUpdateRequestDto: Content { }
+
+extension SharedBusinessCardUpdateRequestDto: Validatable {
+    static func validations(_ validations: inout Validations) {
+        validations.add("thirdPartyName", as: String?.self, is: .count(...100) || .nil, required: false)
+        validations.add("thirdPartyEmail", as: String?.self, is: .email || .nil, required: false)
+        validations.add("sharedCardUrl", as: String.self, is: .url)
+    }
+}

--- a/Sources/VernissageServer/Errors/EntityNotFoundError.swift
+++ b/Sources/VernissageServer/Errors/EntityNotFoundError.swift
@@ -29,6 +29,8 @@ enum EntityNotFoundError: String, Error {
     case categoryNotFound
     case followingImportNotFound
     case articleNotFound
+    case businessCardNotFound
+    case sharedBusinessCardNotFound
 }
 
 extension EntityNotFoundError: LocalizedTerminateError {
@@ -58,6 +60,8 @@ extension EntityNotFoundError: LocalizedTerminateError {
         case .categoryNotFound: return "Category not exists."
         case .followingImportNotFound: return "Following import not exists."
         case .articleNotFound: return "Article not exists."
+        case .businessCardNotFound: return "Business card not exists."
+        case .sharedBusinessCardNotFound: return "Shared business card not exists."
         }
     }
 

--- a/Sources/VernissageServer/Errors/SharedBusinessCardError.swift
+++ b/Sources/VernissageServer/Errors/SharedBusinessCardError.swift
@@ -1,0 +1,39 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+import ExtendedError
+
+/// Errors returned during shared business cards operations.
+enum SharedBusinessCardError: String, Error {
+    case incorrectSharedBusinessCardId
+    case incorrectCode
+    case businessCardNotFound
+    case missingEmail
+}
+
+extension SharedBusinessCardError: LocalizedTerminateError {
+    var status: HTTPResponseStatus {
+        return .badRequest
+    }
+
+    var reason: String {
+        switch self {
+        case .incorrectSharedBusinessCardId: return "Incorrect shared business card id."
+        case .incorrectCode: return "Incorrect code."
+        case .businessCardNotFound: return "Business card not found."
+        case .missingEmail: return "Missing email."
+        }
+    }
+
+    var identifier: String {
+        return "shared-business-card"
+    }
+
+    var code: String {
+        return self.rawValue
+    }
+}

--- a/Sources/VernissageServer/Extensions/Application+Seed.swift
+++ b/Sources/VernissageServer/Extensions/Application+Seed.swift
@@ -51,6 +51,7 @@ extension Application {
         try await ensureSettingExists(on: database, existing: settings, key: .statusPurgeAfterDays, value: .int(180))
         try await ensureSettingExists(on: database, existing: settings, key: .imagesUrl, value: .string(""))
         try await ensureSettingExists(on: database, existing: settings, key: .showNews, value: .boolean(false))
+        try await ensureSettingExists(on: database, existing: settings, key: .showSharedBusinessCards, value: .boolean(false))
 
         // Financial support.
         try await ensureSettingExists(on: database, existing: settings, key: .totalCost, value: .int(0))
@@ -758,6 +759,26 @@ extension Application {
         
         try await ensureLocalizableExists(on: database,
                                           existing: localizables,
+                                          code: "email.sharedBusinessCard.subject",
+                                          locale: "en_US",
+                                          system: "\(Constants.name) - Business card has been shared with you")
+        
+        try await ensureLocalizableExists(on: database,
+                                          existing: localizables,
+                                          code: "email.sharedBusinessCard.body",
+                                          locale: "en_US",
+                                          system:
+"""
+<html>
+    <body>
+        <div>Hi {name},</div>
+        <div>The photographer has shared their business card with you. You can access it at this <a href='{cardUrl}'>link</a>. It is private and visible only to you and the photographer.</div>
+    </body>
+</html>
+""")
+        
+        try await ensureLocalizableExists(on: database,
+                                          existing: localizables,
                                           code: "email.confirmEmail.subject",
                                           locale: "pl_PL",
                                           system: "\(Constants.name) - Confirm email")
@@ -812,6 +833,26 @@ extension Application {
     <body>
         <div>Cześć {name},</div>
         <div>Twoje archiwum jest gotowe do <a href='{archiveUrl}'>pobrania</a>.</div>
+    </body>
+</html>
+""")
+        
+        try await ensureLocalizableExists(on: database,
+                                          existing: localizables,
+                                          code: "email.sharedBusinessCard.subject",
+                                          locale: "pl_PL",
+                                          system: "\(Constants.name) - Udostępniono nową wizytówkę")
+        
+        try await ensureLocalizableExists(on: database,
+                                          existing: localizables,
+                                          code: "email.sharedBusinessCard.body",
+                                          locale: "pl_PL",
+                                          system:
+"""
+<html>
+    <body>
+        <div>Cześć {name},</div>
+        <div>Fotograf udostępnił z tobą swoją wizytówkę. Masz do niej dostęp pod tym <a href='{cardUrl}'>adresem</a>. Jest ona prywatna widoczna tylko dla ciebie oraz dla fotografa.</div>
     </body>
 </html>
 """)

--- a/Sources/VernissageServer/Migrations/CreateBusinessCardFields.swift
+++ b/Sources/VernissageServer/Migrations/CreateBusinessCardFields.swift
@@ -1,0 +1,29 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+import Fluent
+import SQLKit
+
+extension BusinessCardField {
+    struct CreateBusinessCardFields: AsyncMigration {
+        func prepare(on database: Database) async throws {
+            try await database
+                .schema(BusinessCardField.schema)
+                .field(.id, .int64, .identifier(auto: false))
+                .field("businessCardId", .int64, .required, .references(BusinessCard.schema, "id"))
+                .field("key", .varchar(200), .required)
+                .field("value", .varchar(500), .required)
+                .field("createdAt", .datetime)
+                .field("updatedAt", .datetime)
+                .create()
+        }
+        
+        func revert(on database: Database) async throws {
+            try await database.schema(BusinessCardField.schema).delete()
+        }
+    }
+}

--- a/Sources/VernissageServer/Migrations/CreateBusinessCards.swift
+++ b/Sources/VernissageServer/Migrations/CreateBusinessCards.swift
@@ -1,0 +1,36 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+import Fluent
+import SQLKit
+
+extension BusinessCard {
+    struct CreateBusinessCards: AsyncMigration {
+        func prepare(on database: Database) async throws {
+            try await database
+                .schema(BusinessCard.schema)
+                .field(.id, .int64, .identifier(auto: false))
+                .field("userId", .int64, .required, .references(User.schema, "id"))
+                .field("title", .varchar(200), .required)
+                .field("subtitle", .varchar(500))
+                .field("body", .string)
+                .field("website", .varchar(500))
+                .field("telephone", .varchar(50))
+                .field("email", .varchar(500))
+                .field("color1", .varchar(50), .required)
+                .field("color2", .varchar(50), .required)
+                .field("color3", .varchar(50), .required)
+                .field("createdAt", .datetime)
+                .field("updatedAt", .datetime)
+                .create()
+        }
+        
+        func revert(on database: Database) async throws {
+            try await database.schema(BusinessCard.schema).delete()
+        }
+    }
+}

--- a/Sources/VernissageServer/Migrations/CreateSharedBusinessCardMessages.swift
+++ b/Sources/VernissageServer/Migrations/CreateSharedBusinessCardMessages.swift
@@ -1,0 +1,29 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+import Fluent
+import SQLKit
+
+extension SharedBusinessCardMessage {
+    struct CreateSharedBusinessCardMessages: AsyncMigration {
+        func prepare(on database: Database) async throws {
+            try await database
+                .schema(SharedBusinessCardMessage.schema)
+                .field(.id, .int64, .identifier(auto: false))
+                .field("sharedBusinessCardId", .int64, .required, .references(SharedBusinessCard.schema, "id"))
+                .field("userId", .int64, .references(User.schema, "id"))
+                .field("message", .varchar(500), .required)
+                .field("createdAt", .datetime)
+                .field("updatedAt", .datetime)
+                .create()
+        }
+        
+        func revert(on database: Database) async throws {
+            try await database.schema(SharedBusinessCardMessage.schema).delete()
+        }
+    }
+}

--- a/Sources/VernissageServer/Migrations/CreateSharedBusinessCards.swift
+++ b/Sources/VernissageServer/Migrations/CreateSharedBusinessCards.swift
@@ -1,0 +1,33 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+import Fluent
+import SQLKit
+
+extension SharedBusinessCard {
+    struct CreateSharedBusinessCards: AsyncMigration {
+        func prepare(on database: Database) async throws {
+            try await database
+                .schema(SharedBusinessCard.schema)
+                .field(.id, .int64, .identifier(auto: false))
+                .field("businessCardId", .int64, .required, .references(BusinessCard.schema, "id"))
+                .field("code", .varchar(64), .required)
+                .field("title", .varchar(200), .required)
+                .field("note", .varchar(500))
+                .field("thirdPartyName", .varchar(100), .required)
+                .field("thirdPartyEmail", .varchar(500))
+                .field("revokedAt", .datetime)
+                .field("createdAt", .datetime)
+                .field("updatedAt", .datetime)
+                .create()
+        }
+        
+        func revert(on database: Database) async throws {
+            try await database.schema(SharedBusinessCard.schema).delete()
+        }
+    }
+}

--- a/Sources/VernissageServer/Models/ApplicationSettings.swift
+++ b/Sources/VernissageServer/Models/ApplicationSettings.swift
@@ -27,6 +27,8 @@ struct ApplicationSettings {
     let maxMediaAttachments: Int
     let imageSizeLimit: Int
     let statusPurgeAfterDays: Int
+    let showNews: Bool
+    let showSharedBusinessCards: Bool
     
     // Email settings.
     let emailFromAddress: String
@@ -113,7 +115,9 @@ struct ApplicationSettings {
          showEditorsChoiceForAnonymous: Bool = false,
          showEditorsUsersChoiceForAnonymous: Bool = false,
          showHashtagsForAnonymous: Bool = false,
-         showCategoriesForAnonymous: Bool = false
+         showCategoriesForAnonymous: Bool = false,
+         showNews: Bool = false,
+         showSharedBusinessCards: Bool = false
     ) {
         self.baseAddress = baseAddress
         self.domain = domain
@@ -140,6 +144,9 @@ struct ApplicationSettings {
         self.emailFromAddress = emailFromAddress
         self.emailFromName = emailFromName
         self.imagesUrl = imagesUrl
+        
+        self.showNews = showNews
+        self.showSharedBusinessCards = showSharedBusinessCards
         
         if (s3Address ?? "").isEmpty == false {
             self.s3Address = s3Address

--- a/Sources/VernissageServer/Models/BusinessCard.swift
+++ b/Sources/VernissageServer/Models/BusinessCard.swift
@@ -1,0 +1,90 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Fluent
+import Vapor
+
+/// User's business card.
+final class BusinessCard: Model, @unchecked Sendable {
+    static let schema: String = "BusinessCards"
+
+    @ID(custom: .id, generatedBy: .user)
+    var id: Int64?
+    
+    @Parent(key: "userId")
+    var user: User
+        
+    @Field(key: "title")
+    var title: String
+
+    @Field(key: "subtitle")
+    var subtitle: String?
+    
+    @Field(key: "body")
+    var body: String?
+
+    @Field(key: "website")
+    var website: String?
+    
+    @Field(key: "telephone")
+    var telephone: String?
+    
+    @Field(key: "email")
+    var email: String?
+    
+    @Field(key: "color1")
+    var color1: String
+
+    @Field(key: "color2")
+    var color2: String
+
+    @Field(key: "color3")
+    var color3: String
+    
+    @Timestamp(key: "createdAt", on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: "updatedAt", on: .update)
+    var updatedAt: Date?
+
+    @Children(for: \.$businessCard)
+    var businessCardFields: [BusinessCardField]
+    
+    @Children(for: \.$businessCard)
+    var sharedBusinessCards: [SharedBusinessCard]
+    
+    init() { }
+
+    convenience init(id: Int64,
+                     userId: Int64,
+                     title: String,
+                     subtitle: String? = nil,
+                     body: String? = nil,
+                     website: String? = nil,
+                     telephone: String? = nil,
+                     email: String? = nil,
+                     color1: String,
+                     color2: String,
+                     color3: String
+    ) {
+        self.init()
+
+        self.id = id
+        self.$user.id = userId
+        self.title = title
+        self.subtitle = subtitle
+        self.body = body
+        self.website = website
+        self.telephone = telephone
+        self.email = email
+        self.color1 = color1
+        self.color2 = color2
+        self.color3 = color3
+    }
+}
+
+/// Allows `BusinessCard` to be encoded to and decoded from HTTP messages.
+extension BusinessCard: Content { }

--- a/Sources/VernissageServer/Models/BusinessCardField.swift
+++ b/Sources/VernissageServer/Models/BusinessCardField.swift
@@ -1,0 +1,49 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Fluent
+import Vapor
+
+/// Field attached to the user's business card.
+final class BusinessCardField: Model, @unchecked Sendable {
+    static let schema = "BusinessCardFields"
+    
+    @ID(custom: .id, generatedBy: .user)
+    var id: Int64?
+    
+    @Parent(key: "businessCardId")
+    var businessCard: BusinessCard
+    
+    @Field(key: "key")
+    var key: String
+    
+    @Field(key: "value")
+    var value: String
+    
+    @Timestamp(key: "createdAt", on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: "updatedAt", on: .update)
+    var updatedAt: Date?
+    
+    init() { }
+    
+    convenience init(id: Int64,
+                     businessCardId: Int64,
+                     key: String,
+                     value: String
+    ) {
+        self.init()
+
+        self.id = id
+        self.$businessCard.id = businessCardId
+        self.key = key
+        self.value = value
+    }
+}
+
+/// Allows `BusinessCardField` to be encoded to and decoded from HTTP messages.
+extension BusinessCardField: Content { }

--- a/Sources/VernissageServer/Models/Event.swift
+++ b/Sources/VernissageServer/Models/Event.swift
@@ -220,6 +220,22 @@ enum EventType: String, Codable, CaseIterable {
     case articlesUpdate
     case articlesDelete
     case articlesDismiss
+
+    case businessCardsRead
+    case businessCardsCreate
+    case businessCardsUpdate
+    
+    case sharedBusinessCardList
+    case sharedBusinessCardRead
+    case sharedBusinessCardCreate
+    case sharedBusinessCardUpdate
+    case sharedBusinessCardDelete
+    case sharedBusinessCardMessage
+    case sharedBusinessCardRevoke
+    case sharedBusinessCardUnrevoke
+    case sharedBusinessCardReadByThirdParty
+    case sharedBusinessCardUpdateByThirdParty
+    case sharedBusinessCardMessageByThirdParty
 }
 
 final class Event: Model, @unchecked Sendable {

--- a/Sources/VernissageServer/Models/Setting.swift
+++ b/Sources/VernissageServer/Models/Setting.swift
@@ -66,6 +66,7 @@ public enum SettingKey: String {
     case statusPurgeAfterDays
     case imagesUrl
     case showNews
+    case showSharedBusinessCards
     
     // Recaptcha.
     case isRecaptchaEnabled

--- a/Sources/VernissageServer/Models/SharedBusinessCard.swift
+++ b/Sources/VernissageServer/Models/SharedBusinessCard.swift
@@ -1,0 +1,70 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Fluent
+import Vapor
+
+/// User's business card made available to a third party.
+final class SharedBusinessCard: Model, @unchecked Sendable {
+    static let schema: String = "SharedBusinessCards"
+
+    @ID(custom: .id, generatedBy: .user)
+    var id: Int64?
+    
+    @Parent(key: "businessCardId")
+    var businessCard: BusinessCard
+
+    @Field(key: "code")
+    var code: String
+    
+    @Field(key: "title")
+    var title: String
+
+    @Field(key: "note")
+    var note: String?
+    
+    @Field(key: "thirdPartyName")
+    var thirdPartyName: String
+
+    @Field(key: "thirdPartyEmail")
+    var thirdPartyEmail: String?
+
+    @Timestamp(key: "revokedAt", on: .none)
+    var revokedAt: Date?
+    
+    @Timestamp(key: "createdAt", on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: "updatedAt", on: .update)
+    var updatedAt: Date?
+
+    @Children(for: \.$sharedBusinessCard)
+    var messages: [SharedBusinessCardMessage]
+    
+    init() { }
+
+    convenience init(id: Int64,
+                     businessCardId: Int64,
+                     code: String,
+                     title: String,
+                     note: String? = nil,
+                     thirdPartyName: String,
+                     thirdPartyEmail: String? = nil
+    ) {
+        self.init()
+
+        self.id = id
+        self.$businessCard.id = businessCardId
+        self.code = code
+        self.title = title
+        self.note = note
+        self.thirdPartyName = thirdPartyName
+        self.thirdPartyEmail = thirdPartyEmail
+    }
+}
+
+/// Allows `SharedBusinessCard` to be encoded to and decoded from HTTP messages.
+extension SharedBusinessCard: Content { }

--- a/Sources/VernissageServer/Models/SharedBusinessCardMessage.swift
+++ b/Sources/VernissageServer/Models/SharedBusinessCardMessage.swift
@@ -1,0 +1,49 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Fluent
+import Vapor
+
+/// User's shared business card message.
+final class SharedBusinessCardMessage: Model, @unchecked Sendable {
+    static let schema: String = "SharedBusinessCardMessages"
+
+    @ID(custom: .id, generatedBy: .user)
+    var id: Int64?
+    
+    @Parent(key: "sharedBusinessCardId")
+    var sharedBusinessCard: SharedBusinessCard
+
+    @OptionalParent(key: "userId")
+    var user: User?
+    
+    @Field(key: "message")
+    var message: String
+
+    @Timestamp(key: "createdAt", on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: "updatedAt", on: .update)
+    var updatedAt: Date?
+    
+    init() { }
+
+    convenience init(id: Int64,
+                     sharedBusinessCardId: Int64,
+                     userId: Int64? = nil,
+                     message: String
+    ) {
+        self.init()
+
+        self.id = id
+        self.$sharedBusinessCard.id = sharedBusinessCardId
+        self.$user.id = userId
+        self.message = message
+    }
+}
+
+/// Allows `SharedBusinessCardMessage` to be encoded to and decoded from HTTP messages.
+extension SharedBusinessCardMessage: Content { }

--- a/Sources/VernissageServer/Services/BusinessCardsService.swift
+++ b/Sources/VernissageServer/Services/BusinessCardsService.swift
@@ -1,0 +1,66 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2024 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+import Fluent
+
+extension Application.Services {
+    struct BusinessCardsServiceKey: StorageKey {
+        typealias Value = BusinessCardsServiceType
+    }
+
+    var businessCardsService: BusinessCardsServiceType {
+        get {
+            self.application.storage[BusinessCardsServiceKey.self] ?? BusinessCardsService()
+        }
+        nonmutating set {
+            self.application.storage[BusinessCardsServiceKey.self] = newValue
+        }
+    }
+}
+
+@_documentation(visibility: private)
+protocol BusinessCardsServiceType: Sendable {
+    func convertToDto(businessCard: BusinessCard, on context: ExecutionContext) -> BusinessCardDto
+    func convertToDto(sharedBusinessCard: SharedBusinessCard, messages: [SharedBusinessCardMessage]?, on context: ExecutionContext) -> SharedBusinessCardDto
+    func convertToDto(sharedBusinessCard: SharedBusinessCard, with businessCard: BusinessCard, clearSensitive: Bool, on context: ExecutionContext) -> SharedBusinessCardDto
+}
+
+/// A service for managing user's business card.
+final class BusinessCardsService: BusinessCardsServiceType {
+    func convertToDto(businessCard: BusinessCard, on context: ExecutionContext) -> BusinessCardDto {
+        let baseImagesPath = context.services.storageService.getBaseImagesPath(on: context)
+        let baseAddress = context.settings.cached?.baseAddress ?? ""
+        
+        return BusinessCardDto(from: businessCard, baseAddress: baseAddress, baseImagesPath: baseImagesPath)
+    }
+    
+    func convertToDto(sharedBusinessCard: SharedBusinessCard, messages: [SharedBusinessCardMessage]? = nil, on context: ExecutionContext) -> SharedBusinessCardDto {
+        let baseImagesPath = context.services.storageService.getBaseImagesPath(on: context)
+        let baseAddress = context.settings.cached?.baseAddress ?? ""
+        
+        return SharedBusinessCardDto(from: sharedBusinessCard, messages: messages, baseAddress: baseAddress, baseImagesPath: baseImagesPath)
+    }
+    
+    func convertToDto(sharedBusinessCard: SharedBusinessCard, with businessCard: BusinessCard, clearSensitive: Bool, on context: ExecutionContext) -> SharedBusinessCardDto {
+        let baseImagesPath = context.services.storageService.getBaseImagesPath(on: context)
+        let baseAddress = context.settings.cached?.baseAddress ?? ""
+        
+        let businessCardDto = BusinessCardDto(from: businessCard, baseAddress: baseAddress, baseImagesPath: baseImagesPath)
+        var sharedBusinessCardDto = SharedBusinessCardDto(from: sharedBusinessCard,
+                                                          messages: sharedBusinessCard.messages,
+                                                          businessCardDto: businessCardDto,
+                                                          baseAddress: baseAddress,
+                                                          baseImagesPath: baseImagesPath)
+        
+        if clearSensitive {
+            sharedBusinessCardDto.title = ""
+            sharedBusinessCardDto.note = ""
+        }
+        
+        return sharedBusinessCardDto
+    }
+}

--- a/Sources/VernissageServer/Services/EmailsService.swift
+++ b/Sources/VernissageServer/Services/EmailsService.swift
@@ -30,6 +30,7 @@ protocol EmailsServiceType: Sendable {
     func dispatchForgotPasswordEmail(user: User, redirectBaseUrl: String, on request: Request) async throws
     func dispatchConfirmAccountEmail(user: User, redirectBaseUrl: String, on request: Request) async throws
     func dispatchArchiveReadyEmail(archive: Archive, on context: ExecutionContext) async throws
+    func dispatchSharedBusinessCardEmail(sharedBusinessCard: SharedBusinessCard, sharedCardUrl: String, on context: ExecutionContext) async throws
 }
 
 /// A website for sending email messages.
@@ -168,6 +169,46 @@ final class EmailsService: EmailsServiceType {
         let email = EmailDto(to: emailAddressDto,
                              subject: localizedEmailSubject,
                              body: String(format: localizedEmailBody, userName, archiveUrl)
+            )
+            
+        try await context
+            .queues(.emails)
+            .dispatch(EmailJob.self, email, maxRetryCount: 3)
+    }
+    
+    func dispatchSharedBusinessCardEmail(sharedBusinessCard: SharedBusinessCard, sharedCardUrl: String, on context: ExecutionContext) async throws {
+        guard let emailAddress = sharedBusinessCard.thirdPartyEmail, emailAddress.isEmpty == false else {
+            throw ArchiveError.missingEmail
+        }
+        
+        guard let businessCard = try await BusinessCard.query(on: context.db)
+            .with(\.$user)
+            .filter(\.$id == sharedBusinessCard.$businessCard.id)
+            .first() else {
+            throw EntityNotFoundError.businessCardNotFound
+        }
+        
+        let userName = businessCard.user.getUserName()
+        let emailAddressDto = EmailAddressDto(address: emailAddress, name: sharedBusinessCard.thirdPartyName)
+
+        let emailVariables = [
+            "name": userName,
+            "cardUrl": sharedCardUrl
+        ]
+        
+        let localizablesService = context.services.localizablesService
+        let localizedEmailSubject = try await localizablesService.get(code: "email.sharedBusinessCard.subject",
+                                                                      locale: "en_US",
+                                                                      on: context.db)
+
+        let localizedEmailBody = try await localizablesService.get(code: "email.sharedBusinessCard.body",
+                                                                   locale: "en_US",
+                                                                   variables: emailVariables,
+                                                                   on: context.db)
+        
+        let email = EmailDto(to: emailAddressDto,
+                             subject: localizedEmailSubject,
+                             body: String(format: localizedEmailBody, userName, sharedCardUrl)
             )
             
         try await context

--- a/Sources/VernissageServer/Services/SettingsService.swift
+++ b/Sources/VernissageServer/Services/SettingsService.swift
@@ -103,7 +103,7 @@ final class SettingsService: SettingsServiceType {
             showHashtagsForAnonymous: settingsFromDb.getBool(.showHashtagsForAnonymous) ?? false,
             showCategoriesForAnonymous: settingsFromDb.getBool(.showCategoriesForAnonymous) ?? false,
             showNews: settingsFromDb.getBool(.showNews) ?? false,
-            showSharedBusinessCards: settingsFromDb.getBool(.showSharedBusinessCards) ?? false,
+            showSharedBusinessCards: settingsFromDb.getBool(.showSharedBusinessCards) ?? false
         )
         
         return applicationSettings

--- a/Sources/VernissageServer/Services/SettingsService.swift
+++ b/Sources/VernissageServer/Services/SettingsService.swift
@@ -101,7 +101,9 @@ final class SettingsService: SettingsServiceType {
             showEditorsChoiceForAnonymous: settingsFromDb.getBool(.showEditorsChoiceForAnonymous) ?? false,
             showEditorsUsersChoiceForAnonymous: settingsFromDb.getBool(.showEditorsUsersChoiceForAnonymous) ?? false,
             showHashtagsForAnonymous: settingsFromDb.getBool(.showHashtagsForAnonymous) ?? false,
-            showCategoriesForAnonymous: settingsFromDb.getBool(.showCategoriesForAnonymous) ?? false
+            showCategoriesForAnonymous: settingsFromDb.getBool(.showCategoriesForAnonymous) ?? false,
+            showNews: settingsFromDb.getBool(.showNews) ?? false,
+            showSharedBusinessCards: settingsFromDb.getBool(.showSharedBusinessCards) ?? false,
         )
         
         return applicationSettings

--- a/Sources/VernissageServer/VernissageServer.docc/VernissageServer.md
+++ b/Sources/VernissageServer/VernissageServer.docc/VernissageServer.md
@@ -79,6 +79,7 @@ can be added by the system administrator.
 - ``AuthenticationClientsController``
 - ``AvatarsController``
 - ``BookmarksController``
+- ``BusinessCardsController``
 - ``CategoriesController``
 - ``CountriesController``
 - ``ErrorItemsController``
@@ -106,6 +107,7 @@ can be added by the system administrator.
 - ``RssController``
 - ``SearchController``
 - ``SettingsController``
+- ``SharedBusinessCardsController``
 - ``StatusesController``
 - ``TimelinesController``
 - ``TrendingController``
@@ -132,6 +134,8 @@ can be added by the system administrator.
 - ``AuthClientDto``
 - ``AttachmentHashtagDto``
 - ``BooleanResponseDto``
+- ``BusinessCardDto``
+- ``BusinessCardFieldDto``
 - ``CategoryDto``
 - ``CategoryHashtagDto``
 - ``ChangeEmailDto``
@@ -189,6 +193,9 @@ can be added by the system administrator.
 - ``SearchResultDto``
 - ``SearchTypeDto``
 - ``SettingsDto``
+- ``SharedBusinessCardDto``
+- ``SharedBusinessCardMessageDto``
+- ``SharedBusinessCardUpdateRequestDto``
 - ``SimpleRuleDto``
 - ``StatusContextDto``
 - ``StatusDeleteJobDto``
@@ -219,6 +226,7 @@ can be added by the system administrator.
 - ``ArticlesService``
 - ``ArchivesService``
 - ``AtomService``
+- ``BusinessCardsService``
 - ``CaptchaService``
 - ``CryptoService``
 - ``EmailsService``
@@ -267,6 +275,7 @@ can be added by the system administrator.
 - ``ActivityPubError``
 - ``AttachmentError``
 - ``ArchiveError``
+- ``ArticleError``
 - ``AuthClientError``
 - ``AvatarError``
 - ``CategoryError``
@@ -293,6 +302,7 @@ can be added by the system administrator.
 - ``RoleError``
 - ``RuleError``
 - ``SettingError``
+- ``SharedBusinessCardError``
 - ``StatusError``
 - ``StorageError``
 - ``TemporaryFileError``
@@ -344,12 +354,15 @@ can be added by the system administrator.
 - ``ApplicationSettings``
 - ``Attachment``
 - ``Article``
+- ``ArticleRead``
 - ``ArticleVisibility``
 - ``ArticleVisibilityType``
 - ``Archive``
 - ``ArchiveStatus``
 - ``AuthClient``
 - ``AuthClientType``
+- ``BusinessCard``
+- ``BusinessCardField``
 - ``Category``
 - ``CategoryHashtag``
 - ``Country``
@@ -388,6 +401,8 @@ can be added by the system administrator.
 - ``Setting``
 - ``SettingKey``
 - ``SettingValue``
+- ``SharedBusinessCard``
+- ``SharedBusinessCardMessage``
 - ``Status``
 - ``StatusBookmark``
 - ``StatusEmoji``

--- a/Tests/VernissageServerTests/AcceptanceTests/BusinessCardsController/BusinessCardsCreateActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/BusinessCardsController/BusinessCardsCreateActionTests.swift
@@ -1,0 +1,275 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("BusinessCards (POST /business-cards)", .serialized, .tags(.businessCards))
+    struct BusinessCardsCreateActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test("Business card should be created by authorized user")
+        func businessCardShouldBeCreatedByAuthorizedUser() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "larabedox")
+            let businessCardDto = BusinessCardDto(title: "Title larabedox",
+                                                  subtitle: "Subtitle larabedox",
+                                                  body: "Body larabedox",
+                                                  website: "http://website.com",
+                                                  telephone: "+48666777888",
+                                                  email: "larabedox@test.cox",
+                                                  color1: "#00FF00",
+                                                  color2: "#00FF11",
+                                                  color3: "#00AABB")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "larabedox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .POST,
+                body: businessCardDto
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.created, "Response http status code should be created (201).")
+            let businessCard = try await application.getBusinessCard(userId: user.requireID())
+            #expect(businessCard?.title == "Title larabedox", "Business card title should be saved.")
+            #expect(businessCard?.subtitle == "Subtitle larabedox", "Business card subtitle should be saved.")
+            #expect(businessCard?.body == "Body larabedox", "Business card body should be saved.")
+            #expect(businessCard?.website == "http://website.com", "Business card website should be saved.")
+            #expect(businessCard?.telephone == "+48666777888", "Business card telephone should be saved.")
+            #expect(businessCard?.email == "larabedox@test.cox", "Business card email should be saved.")
+            #expect(businessCard?.color1 == "#00FF00", "Business card color1 should be saved.")
+            #expect(businessCard?.color2 == "#00FF11", "Business card color2 should be saved.")
+            #expect(businessCard?.color3 == "#00AABB", "Business card color3 should be saved.")
+        }
+        
+        @Test("Business card should not be created if title was not specified")
+        func businessCardShouldNotBeCreatedIfTitleWasNotSpecified() async throws {
+            
+            // Arrange.
+            _ = try await application.createUser(userName: "nikobedox")
+            let businessCardDto = BusinessCardDto(title: "", color1: "#000000", color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "nikobedox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .POST,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("title") == "is less than minimum of 1 character(s)")
+        }
+        
+        @Test("Business card should not be created if title is too long")
+        func businessCardShouldNotBeCreatedIfTitleIsTooLong() async throws {
+            
+            // Arrange.
+            _ = try await application.createUser(userName: "robbedox")
+            let businessCardDto = BusinessCardDto(title: String.createRandomString(length: 201), color1: "#000000", color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "robbedox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .POST,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("title") == "is greater than maximum of 200 character(s)")
+        }
+        
+        @Test("Business card should not be created if subtitle is too long")
+        func businessCardShouldNotBeCreatedIfSubtitleIsTooLong() async throws {
+            
+            // Arrange.
+            _ = try await application.createUser(userName: "adkabedox")
+            let businessCardDto = BusinessCardDto(title: "Title", subtitle: String.createRandomString(length: 501), color1: "#000000", color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "adkabedox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .POST,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("subtitle") == "is greater than maximum of 500 character(s) and is not null")
+        }
+        
+        @Test("Business card should not be created if website is too long")
+        func businessCardShouldNotBeCreatedIfWebsiteIsTooLong() async throws {
+            
+            // Arrange.
+            _ = try await application.createUser(userName: "madziabedox")
+            let businessCardDto = BusinessCardDto(title: "Title", website: String.createRandomString(length: 501), color1: "#000000", color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "madziabedox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .POST,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("website") == "is greater than maximum of 500 character(s) and is not null")
+        }
+        
+        @Test("Business card should not be created if telephone is too long")
+        func businessCardShouldNotBeCreatedIfTelephoneIsTooLong() async throws {
+            
+            // Arrange.
+            _ = try await application.createUser(userName: "idabedox")
+            let businessCardDto = BusinessCardDto(title: "Title", telephone: String.createRandomString(length: 51), color1: "#000000", color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "idabedox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .POST,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("telephone") == "is greater than maximum of 50 character(s) and is not null")
+        }
+        
+        @Test("Business card should not be created if email is too long")
+        func businessCardShouldNotBeCreatedIfEmailIsTooLong() async throws {
+            
+            // Arrange.
+            _ = try await application.createUser(userName: "adrianbedox")
+            let businessCardDto = BusinessCardDto(title: "Title", email: String.createRandomString(length: 501), color1: "#000000", color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "adrianbedox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .POST,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("email") == "is greater than maximum of 500 character(s) and is not null")
+        }
+        
+        @Test("Business card should not be created if color1 is too long")
+        func businessCardShouldNotBeCreatedIfColor1IsTooLong() async throws {
+            
+            // Arrange.
+            _ = try await application.createUser(userName: "jolabedox")
+            let businessCardDto = BusinessCardDto(title: "Title", color1: String.createRandomString(length: 51), color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "jolabedox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .POST,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("color1") == "is greater than maximum of 50 character(s)")
+        }
+        
+        @Test("Business card should not be created if color2 is too long")
+        func businessCardShouldNotBeCreatedIfColor2IsTooLong() async throws {
+            
+            // Arrange.
+            _ = try await application.createUser(userName: "jankabedox")
+            let businessCardDto = BusinessCardDto(title: "Title", color1: "#000000", color2: String.createRandomString(length: 51), color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "jankabedox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .POST,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("color2") == "is greater than maximum of 50 character(s)")
+        }
+        
+        @Test("Business card should not be created if color3 is too long")
+        func businessCardShouldNotBeCreatedIfColor3IsTooLong() async throws {
+            
+            // Arrange.
+            _ = try await application.createUser(userName: "moniabedox")
+            let businessCardDto = BusinessCardDto(title: "Title", color1: "#000000", color2: "#000000", color3: String.createRandomString(length: 51))
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "moniabedox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .POST,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("color3") == "is greater than maximum of 50 character(s)")
+        }
+                        
+        @Test("Unauthorize should be returnedd for not authorized user")
+        func unauthorizeShouldBeReturneddForNotAuthorizedUser() async throws {
+            
+            // Arrange.
+            let businessCardDto = BusinessCardDto(title: "Title", color1: "#000000", color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/business-cards",
+                method: .POST,
+                body: businessCardDto
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthoroized (401).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/BusinessCardsController/BusinessCardsReadActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/BusinessCardsController/BusinessCardsReadActionTests.swift
@@ -1,0 +1,58 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("BusinessCards (GET /business-cards)", .serialized, .tags(.businessCards))
+    struct BusinessCardsReadActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test("Business card should be returned for authorized user")
+        func businessCardShoulrBeReturnedForAuthorizedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "wictorbumor")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            
+            // Act.
+            let result = try await application.getResponse(
+                as: .user(userName: "wictorbumor", password: "p@ssword"),
+                to: "/business-cards",
+                method: .GET,
+                decodeTo: BusinessCardDto.self
+            )
+            
+            // Assert.
+            #expect(result.id != nil, "Business card should be returned.")
+            #expect(result.title == "Title", "Business card title should be returned.")
+        }
+        
+        @Test("Unauthorized should be returned for not authorized user")
+        func unauthorizedShouldBeReturendForNotAuthorizedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "martinbumor")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+
+            // Act.
+            let response = try await application.getErrorResponse(
+                to: "/business-cards",
+                method: .GET
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthorized (401).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/BusinessCardsController/BusinessCardsUpdateActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/BusinessCardsController/BusinessCardsUpdateActionTests.swift
@@ -1,0 +1,285 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("BusinessCards (PUT /business-cards)", .serialized, .tags(.businessCards))
+    struct BusinessCardsUpdateActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test("Business card should be updated by authorized user")
+        func businessCardShouldBeUpdatedByAuthorizedUser() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "laratrupnox")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let businessCardDto = BusinessCardDto(title: "Title laratrupnox",
+                                                  subtitle: "Subtitle laratrupnox",
+                                                  body: "Body laratrupnox",
+                                                  website: "http://website.com",
+                                                  telephone: "+48666777888",
+                                                  email: "laratrupnox@test.cox",
+                                                  color1: "#00FF00",
+                                                  color2: "#00FF11",
+                                                  color3: "#00AABB")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "laratrupnox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .PUT,
+                body: businessCardDto
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.ok, "Response http status code should be created (201).")
+            let businessCard = try await application.getBusinessCard(userId: user.requireID())
+            #expect(businessCard?.title == "Title laratrupnox", "Business card title should be saved.")
+            #expect(businessCard?.subtitle == "Subtitle laratrupnox", "Business card subtitle should be saved.")
+            #expect(businessCard?.body == "Body laratrupnox", "Business card body should be saved.")
+            #expect(businessCard?.website == "http://website.com", "Business card website should be saved.")
+            #expect(businessCard?.telephone == "+48666777888", "Business card telephone should be saved.")
+            #expect(businessCard?.email == "laratrupnox@test.cox", "Business card email should be saved.")
+            #expect(businessCard?.color1 == "#00FF00", "Business card color1 should be saved.")
+            #expect(businessCard?.color2 == "#00FF11", "Business card color2 should be saved.")
+            #expect(businessCard?.color3 == "#00AABB", "Business card color3 should be saved.")
+        }
+        
+        @Test("Business card should not be updated if title was not specified")
+        func businessCardShouldNotBeUpdatedIfTitleWasNotSpecified() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "nikotrupnox")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let businessCardDto = BusinessCardDto(title: "", color1: "#000000", color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "nikotrupnox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .PUT,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("title") == "is less than minimum of 1 character(s)")
+        }
+        
+        @Test("Business card should not be updated if title is too long")
+        func businessCardShouldNotBeUpdatedIfTitleIsTooLong() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "robtrupnox")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let businessCardDto = BusinessCardDto(title: String.createRandomString(length: 201), color1: "#000000", color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "robtrupnox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .PUT,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("title") == "is greater than maximum of 200 character(s)")
+        }
+        
+        @Test("Business card should not be updated if subtitle is too long")
+        func businessCardShouldNotBeUpdatedIfSubtitleIsTooLong() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "adkatrupnox")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let businessCardDto = BusinessCardDto(title: "Title", subtitle: String.createRandomString(length: 501), color1: "#000000", color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "adkatrupnox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .PUT,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("subtitle") == "is greater than maximum of 500 character(s) and is not null")
+        }
+        
+        @Test("Business card should not be updated if website is too long")
+        func businessCardShouldNotBeUpdatedIfWebsiteIsTooLong() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "madziatrupnox")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let businessCardDto = BusinessCardDto(title: "Title", website: String.createRandomString(length: 501), color1: "#000000", color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "madziatrupnox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .PUT,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("website") == "is greater than maximum of 500 character(s) and is not null")
+        }
+        
+        @Test("Business card should not be updated if telephone is too long")
+        func businessCardShouldNotBeUpdatedIfTelephoneIsTooLong() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "idatrupnox")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let businessCardDto = BusinessCardDto(title: "Title", telephone: String.createRandomString(length: 51), color1: "#000000", color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "idatrupnox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .PUT,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("telephone") == "is greater than maximum of 50 character(s) and is not null")
+        }
+        
+        @Test("Business card should not be updated if email is too long")
+        func businessCardShouldNotBeUpdatedIfEmailIsTooLong() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "adriantrupnox")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let businessCardDto = BusinessCardDto(title: "Title", email: String.createRandomString(length: 501), color1: "#000000", color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "adriantrupnox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .PUT,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("email") == "is greater than maximum of 500 character(s) and is not null")
+        }
+        
+        @Test("Business card should not be updated if color1 is too long")
+        func businessCardShouldNotBeUpdatedIfColor1IsTooLong() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "jolatrupnox")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let businessCardDto = BusinessCardDto(title: "Title", color1: String.createRandomString(length: 51), color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "jolatrupnox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .PUT,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("color1") == "is greater than maximum of 50 character(s)")
+        }
+        
+        @Test("Business card should not be updated if color2 is too long")
+        func businessCardShouldNotBeUpdatedIfColor2IsTooLong() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "jankatrupnox")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let businessCardDto = BusinessCardDto(title: "Title", color1: "#000000", color2: String.createRandomString(length: 51), color3: "#000000")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "jankatrupnox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .PUT,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("color2") == "is greater than maximum of 50 character(s)")
+        }
+        
+        @Test("Business card should not be updated if color3 is too long")
+        func businessCardShouldNotBeUpdatedIfColor3IsTooLong() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "moniatrupnox")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let businessCardDto = BusinessCardDto(title: "Title", color1: "#000000", color2: "#000000", color3: String.createRandomString(length: 51))
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "moniatrupnox", password: "p@ssword"),
+                to: "/business-cards",
+                method: .PUT,
+                data: businessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("color3") == "is greater than maximum of 50 character(s)")
+        }
+                        
+        @Test("Unauthorize should be returnedd for not authorized user")
+        func unauthorizeShouldBeReturneddForNotAuthorizedUser() async throws {
+            
+            // Arrange.
+            let businessCardDto = BusinessCardDto(title: "Title", color1: "#000000", color2: "#000000", color3: "#000000")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/business-cards",
+                method: .PUT,
+                body: businessCardDto
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthoroized (401).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsCreateActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsCreateActionTests.swift
@@ -1,0 +1,128 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("SharedBusinessCards (POST /shared-business-cards)", .serialized, .tags(.sharedBusinessCards))
+    struct SharedBusinessCardsCreateActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test("Shared business card should be created by authorized user.")
+        func sharedBusinessCardShouldBeCreatedByAuthorizedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "wictorgigopol")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCardDto = SharedBusinessCardDto(title: "Title #1", note: "Note #1")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "wictorgigopol", password: "p@ssword"),
+                to: "/shared-business-cards",
+                method: .POST,
+                body: sharedBusinessCardDto
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.created, "Response http status code should be created (201).")
+            let businessCardFromDatabase = try await application.getSharedBusinessCard(businessCardId: businessCard.requireID())
+            #expect(businessCardFromDatabase.first?.title == "Title #1", "Shared business card title should be saved.")
+            #expect(businessCardFromDatabase.first?.note == "Note #1", "Shared business card note should be saved.")
+        }
+        
+        @Test("Shared business card should not be created if title was not specified.")
+        func sharedBusinessCardShouldNotBeCreatedIfTitleWasNotSpecified() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "moniaoqgigopol")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCardDto = SharedBusinessCardDto(title: "")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "moniaoqgigopol", password: "p@ssword"),
+                to: "/shared-business-cards",
+                method: .POST,
+                data: sharedBusinessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("title") == "is less than minimum of 1 character(s)")
+        }
+        
+        @Test("Shared business card should not be created if title is too long.")
+        func sharedBusinessCardShouldNotBeCreatedIfTitleIsTooLong() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "renomixgigopol")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCardDto = SharedBusinessCardDto(title: String.createRandomString(length: 201))
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "renomixgigopol", password: "p@ssword"),
+                to: "/shared-business-cards",
+                method: .POST,
+                data: sharedBusinessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("title") == "is greater than maximum of 200 character(s)")
+        }
+        
+        @Test("Shared business card should not be created if note is too long.")
+        func sharedBusinessCardShouldNotBeCreatedIfNoteIsTooLong() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "vikolergigopol")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCardDto = SharedBusinessCardDto(title: "Title #11", note: String.createRandomString(length: 501))
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "vikolergigopol", password: "p@ssword"),
+                to: "/shared-business-cards",
+                method: .POST,
+                data: sharedBusinessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("note") == "is greater than maximum of 500 character(s) and is not null")
+        }
+        
+        @Test("Unauthorized should be returned for unauthorized user")
+        func unauthorizedShouldbeReturnedForUnauthorizedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "hrobikgigopol")
+            _ = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCardDto = SharedBusinessCardDto(title: "Title #11")
+
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/shared-business-cards",
+                method: .POST,
+                body: sharedBusinessCardDto)
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthorized (401).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsDeleteActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsDeleteActionTests.swift
@@ -1,0 +1,71 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("SharedBusinessCards (DELTE /shared-business-cards/:id)", .serialized, .tags(.sharedBusinessCards))
+    struct SharedBusinessCardsDeleteActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test("Shared business card should be deleted by authorized user.")
+        func sharedBusinessCardShouldBeCreatedByAuthorizedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "wictormionio")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "wictormionio", password: "p@ssword"),
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? ""),
+                method: .DELETE
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.ok, "Response http status code should be ok (200).")
+            let businessCardFromDatabase = try await application.getSharedBusinessCard(businessCardId: businessCard.requireID())
+            #expect(businessCardFromDatabase.count == 0, "Shared business card should be removed.")
+        }
+
+        @Test("Not found should be returned for wrong shared card id")
+        func notFoundShouldbeReturnedForWrongSharedCardId() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "wnorbimionio")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            _ = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "wnorbimionio", password: "p@ssword"),
+                to: "/shared-business-cards/123",
+                method: .DELETE)
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.notFound, "Response http status code should be notFound (404).")
+        }
+        
+        @Test("Unauthorized should be returned for unauthorized user")
+        func unauthorizedShouldbeReturnedForUnauthorizedUser() async throws {
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/shared-business-cards/111",
+                method: .DELETE)
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthorized (401).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsListActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsListActionTests.swift
@@ -1,0 +1,52 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("SharedBusinessCards (GET /shared-business-cards)", .serialized, .tags(.sharedBusinessCards))
+    struct SharedBusinessCardsListActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test("List of all shared business cards should be returned for authorized user")
+        func listOfSharedBusinessCardsShouldBeReturnedForAuthorizedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "wictorvortex")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            _ = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Title #1", thirdPartyName: "Marcin")
+            _ = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Title #2", thirdPartyName: "Anna")
+            
+            // Act.
+            let results = try await application.getResponse(
+                as: .user(userName: "wictorvortex", password: "p@ssword"),
+                to: "/shared-business-cards",
+                method: .GET,
+                decodeTo: PaginableResultDto<SharedBusinessCardDto>.self
+            )
+            
+            // Assert.
+            #expect(results.data.count > 0, "Shared business cards list should be returned.")
+        }
+        
+        @Test("Unauthorized should be returned for unauthorized user")
+        func unauthorizedShouldbeReturnedForUnauthorizedUser() async throws {
+            // Act.
+            let response = try await application.sendRequest(to: "/shared-business-cards", method: .GET)
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthorized (401).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsMessageActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsMessageActionTests.swift
@@ -1,0 +1,105 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("SharedBusinessCards (POST /shared-business-cards/:id/message)", .serialized, .tags(.sharedBusinessCards))
+    struct SharedBusinessCardsMessageActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test("Massage to shared business card should be created by authorized user")
+        func messageToSharedBusinessCardShouldBeCreatedByAuthoriedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "wictorterbol")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+            let message = SharedBusinessCardMessageDto(message: "New message")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "wictorterbol", password: "p@ssword"),
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? "") + "/message",
+                method: .POST,
+                body: message
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.ok, "Response http status code should be ok (200).")
+            let businessCardFromDatabase = try await application.getSharedBusinessCard(businessCardId: businessCard.requireID())
+            #expect((businessCardFromDatabase.first?.messages.count ?? 0) > 0, "Message should be added to shared business card.")
+        }
+        
+        @Test("Massage to shared business card should not be created to other user business card")
+        func messageToSharedBusinessCardShouldNotBeCreatedToOtherUserBusinessCard() async throws {
+            // Arrange.
+            _ = try await application.createUser(userName: "mariaterbol")
+            let user = try await application.createUser(userName: "annaterbol")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+            let message = SharedBusinessCardMessageDto(message: "New message")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "mariaterbol", password: "p@ssword"),
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? "") + "/message",
+                method: .POST,
+                body: message
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.notFound, "Response http status code should be notFound (404).")
+        }
+
+        @Test("Not found should be returned for wrong shared card id")
+        func notFoundShouldbeReturnedForWrongSharedCardId() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "reniaterbol")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            _ = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+            let message = SharedBusinessCardMessageDto(message: "New message")
+
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "reniaterbol", password: "p@ssword"),
+                to: "/shared-business-cards/123/messages",
+                method: .POST,
+                body: message
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.notFound, "Response http status code should be notFound (404).")
+        }
+        
+        @Test("Unauthorized should be returned for unauthorized user")
+        func unauthorizedShouldbeReturnedForUnauthorizedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "klaudiaterbol")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+            let message = SharedBusinessCardMessageDto(message: "New message")
+
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? "") + "/message",
+                method: .POST,
+                body: message
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthorized (401).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsMessagesByThirdPartyActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsMessagesByThirdPartyActionTests.swift
@@ -1,0 +1,63 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("SharedBusinessCards (POST /shared-business-cards/:id/third-party/message)", .serialized, .tags(.sharedBusinessCards))
+    struct SharedBusinessCardsMessagesByThirdPartyActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test("Massage to shared business card should be created for correct code")
+        func messageToSharedBusinessCardShouldBeCreatedForCorrectCode() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "wictoranioma")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+            let message = SharedBusinessCardMessageDto(message: "New message")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/shared-business-cards/" + sharedBusinessCard.code + "/third-party/message",
+                method: .POST,
+                body: message
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.ok, "Response http status code should be ok (200).")
+            let businessCardFromDatabase = try await application.getSharedBusinessCard(businessCardId: businessCard.requireID())
+            #expect((businessCardFromDatabase.first?.messages.count ?? 0) > 0, "Message should be added to shared business card.")
+        }
+        
+        @Test("Not found should be returned for wrong code")
+        func notFoundShouldbeReturnedForWrongCode() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "reniaanioma")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            _ = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+            let message = SharedBusinessCardMessageDto(message: "New message")
+
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/shared-business-cards/123/third-party/message",
+                method: .POST,
+                body: message
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.notFound, "Response http status code should be notFound (404).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsReadActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsReadActionTests.swift
@@ -1,0 +1,73 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("SharedBusinessCards (GET /shared-business-cards/:id)", .serialized, .tags(.sharedBusinessCards))
+    struct SharedBusinessCardsReadActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test("Shared business card should be returned for authorized user")
+        func sharedBusinessCardShouldBeReturnedForAuthorizedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "wictorretopo")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Title #1", thirdPartyName: "Marcin")
+            
+            // Act.
+            let result = try await application.getResponse(
+                as: .user(userName: "wictorretopo", password: "p@ssword"),
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? ""),
+                method: .GET,
+                decodeTo: SharedBusinessCardDto.self
+            )
+            
+            // Assert.
+            #expect(result.id != nil, "Shared business card should be returned.")
+        }
+
+        @Test("Not found should be returned for wrong id")
+        func notFoundShouldBeReturnedForWrongId() async throws {
+            // Arrange.
+            _ = try await application.createUser(userName: "gorgiretopo")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "gorgiretopo", password: "p@ssword"),
+                to: "/shared-business-cards/512",
+                method: .GET)
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.notFound, "Response http status code should be notFound (404).")
+        }
+        
+        @Test("Unauthorized should be returned for unauthorized user")
+        func unauthorizedShouldbeReturnedForUnauthorizedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "marekretopo")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Title #1", thirdPartyName: "Marcin")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? ""),
+                method: .GET)
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthorized (401).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsReadByThirdPartyActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsReadByThirdPartyActionTests.swift
@@ -1,0 +1,88 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("SharedBusinessCards (GET /shared-business-cards/:id/third-party)", .serialized, .tags(.sharedBusinessCards))
+    struct SharedBusinessCardsReadByThirdPartyActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test("Shared business card should be returned for correct code")
+        func sharedBusinessCardShouldBeReturnedForCorrectCode() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "wictorcodex")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Title #1", thirdPartyName: "Marcin")
+            
+            // Act.
+            let result = try await application.getResponse(
+                to: "/shared-business-cards/" + sharedBusinessCard.code + "/third-party",
+                method: .GET,
+                decodeTo: SharedBusinessCardDto.self
+            )
+            
+            // Assert.
+            #expect(result.id != nil, "Shared business card should be returned.")
+        }
+        
+        @Test("Revoked shared business card should not be returned for correct code")
+        func reveokedSharedBusinessCardShouldNotBeReturnedForCorrectCode() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "georiicodex")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Title #1", thirdPartyName: "Marcin", revokedAt: Date())
+            
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/shared-business-cards/" + sharedBusinessCard.code + "/third-party",
+                method: .GET
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.notFound, "Response http status code should be notFound (404).")
+        }
+        
+        @Test("Shared business card should be returned without sensitive information")
+        func sharedBusinessCardShouldBeReturnedWithoutSnsitiveInformation() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "moikacodex")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Title #1", thirdPartyName: "Marcin")
+            
+            // Act.
+            let result = try await application.getResponse(
+                to: "/shared-business-cards/" + sharedBusinessCard.code + "/third-party",
+                method: .GET,
+                decodeTo: SharedBusinessCardDto.self
+            )
+            
+            // Assert.
+            #expect(result.title == "", "Title should be cleared.")
+            #expect(result.note == "", "Note should be cleared.")
+        }
+
+        @Test("Not found should be returned for wrong code")
+        func notFoundShouldBeReturnedForWrongId() async throws {
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/shared-business-cards/512/third-party",
+                method: .GET)
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.notFound, "Response http status code should be notFound (404).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsRevokeActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsRevokeActionTests.swift
@@ -1,0 +1,97 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("SharedBusinessCards (POST /shared-business-cards/:id/revoke)", .serialized, .tags(.sharedBusinessCards))
+    struct SharedBusinessCardsRevokeActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test("Shared business card should be revoked by authorized user")
+        func sharedBusinessCardShouldBeRevokedByAuthoriedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "wictorreniox")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "wictorreniox", password: "p@ssword"),
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? "") + "/revoke",
+                method: .POST
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.ok, "Response http status code should be ok (200).")
+            let businessCardFromDatabase = try await application.getSharedBusinessCard(businessCardId: businessCard.requireID())
+            #expect(businessCardFromDatabase.first?.revokedAt != nil, "Shared business card should be revoked.")
+        }
+        
+        @Test("Shared business card should not be reveoked for other user business card")
+        func sharedBusinessCardShoudNotBeRevokedForOtherUserBusinessCard() async throws {
+            // Arrange.
+            _ = try await application.createUser(userName: "mariareniox")
+            let user = try await application.createUser(userName: "annareniox")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "mariareniox", password: "p@ssword"),
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? "") + "/revoke",
+                method: .POST
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.notFound, "Response http status code should be notFound (404).")
+        }
+
+        @Test("Not found should be returned for wrong shared card id")
+        func notFoundShouldbeReturnedForWrongSharedCardId() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "reniareniox")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            _ = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "reniareniox", password: "p@ssword"),
+                to: "/shared-business-cards/123/revoke",
+                method: .POST
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.notFound, "Response http status code should be notFound (404).")
+        }
+        
+        @Test("Unauthorized should be returned for unauthorized user")
+        func unauthorizedShouldbeReturnedForUnauthorizedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "klaudiareniox")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? "") + "/revoke",
+                method: .POST
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthorized (401).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsUnrevokeActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsUnrevokeActionTests.swift
@@ -1,0 +1,97 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("SharedBusinessCards (POST /shared-business-cards/:id/unrevoke)", .serialized, .tags(.sharedBusinessCards))
+    struct SharedBusinessCardsUnrevokeActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test("Shared business card should be unrevoked by authorized user")
+        func sharedBusinessCardShouldBeUnrevokedByAuthoriedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "wictorferdix")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia", revokedAt: Date())
+            
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "wictorferdix", password: "p@ssword"),
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? "") + "/unrevoke",
+                method: .POST
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.ok, "Response http status code should be ok (200).")
+            let businessCardFromDatabase = try await application.getSharedBusinessCard(businessCardId: businessCard.requireID())
+            #expect(businessCardFromDatabase.first?.revokedAt == nil, "Shared business card should be unrevoked.")
+        }
+        
+        @Test("Shared business card should not be reveoked for other user business card")
+        func sharedBusinessCardShoudNotBeRevokedForOtherUserBusinessCard() async throws {
+            // Arrange.
+            _ = try await application.createUser(userName: "mariaferdix")
+            let user = try await application.createUser(userName: "annaferdix")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia", revokedAt: Date())
+            
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "mariaferdix", password: "p@ssword"),
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? "") + "/unrevoke",
+                method: .POST
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.notFound, "Response http status code should be notFound (404).")
+        }
+
+        @Test("Not found should be returned for wrong shared card id")
+        func notFoundShouldbeReturnedForWrongSharedCardId() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "reniaferdix")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            _ = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia", revokedAt: Date())
+
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "reniaferdix", password: "p@ssword"),
+                to: "/shared-business-cards/123/unrevoke",
+                method: .POST
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.notFound, "Response http status code should be notFound (404).")
+        }
+        
+        @Test("Unauthorized should be returned for unauthorized user")
+        func unauthorizedShouldbeReturnedForUnauthorizedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "klaudiaferdix")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia", revokedAt: Date())
+
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? "") + "/unrevoke",
+                method: .POST
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthorized (401).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsUpdateActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsUpdateActionTests.swift
@@ -1,0 +1,133 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("SharedBusinessCards (PUT /shared-business-cards/:id)", .serialized, .tags(.sharedBusinessCards))
+    struct SharedBusinessCardsUpdateActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test("Shared business card should be updated by authorized user.")
+        func sharedBusinessCardShouldBeUpdatedByAuthorizedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "wictoryopiop")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+            let sharedBusinessCardDto = SharedBusinessCardDto(title: "Title #1", note: "Note #1")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "wictoryopiop", password: "p@ssword"),
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? ""),
+                method: .PUT,
+                body: sharedBusinessCardDto
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.ok, "Response http status code should be ok (200).")
+            let businessCardFromDatabase = try await application.getSharedBusinessCard(businessCardId: businessCard.requireID())
+            #expect(businessCardFromDatabase.first?.title == "Title #1", "Shared business card title should be saved.")
+            #expect(businessCardFromDatabase.first?.note == "Note #1", "Shared business card note should be saved.")
+        }
+        
+        @Test("Shared business card should not be updated if title was not specified.")
+        func sharedBusinessCardShouldNotBeUpdatedIfTitleWasNotSpecified() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "moniaoqyopiop")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+            let sharedBusinessCardDto = SharedBusinessCardDto(title: "")
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "moniaoqyopiop", password: "p@ssword"),
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? ""),
+                method: .PUT,
+                data: sharedBusinessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("title") == "is less than minimum of 1 character(s)")
+        }
+        
+        @Test("Shared business card should not be updated if title is too long.")
+        func sharedBusinessCardShouldNotBeUpdatedIfTitleIsTooLong() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "renomixyopiop")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+            let sharedBusinessCardDto = SharedBusinessCardDto(title: String.createRandomString(length: 201))
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "renomixyopiop", password: "p@ssword"),
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? ""),
+                method: .PUT,
+                data: sharedBusinessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("title") == "is greater than maximum of 200 character(s)")
+        }
+        
+        @Test("Shared business card should not be updated if note is too long.")
+        func sharedBusinessCardShouldNotBeUpdatedIfNoteIsTooLong() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "vikoleryopiop")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+            let sharedBusinessCardDto = SharedBusinessCardDto(title: "Title #11", note: String.createRandomString(length: 501))
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "vikoleryopiop", password: "p@ssword"),
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? ""),
+                method: .PUT,
+                data: sharedBusinessCardDto
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.badRequest, "Response http status code should be bad request (400).")
+            #expect(errorResponse.error.code == "validationError", "Error code should be equal 'validationError'.")
+            #expect(errorResponse.error.reason == "Validation errors occurs.")
+            #expect(errorResponse.error.failures?.getFailure("note") == "is greater than maximum of 500 character(s) and is not null")
+        }
+        
+        @Test("Unauthorized should be returned for unauthorized user")
+        func unauthorizedShouldbeReturnedForUnauthorizedUser() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "hrobikyopiop")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Place", thirdPartyName: "Monia")
+            let sharedBusinessCardDto = SharedBusinessCardDto(title: "Title #11")
+
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/shared-business-cards/" + (sharedBusinessCard.stringId() ?? ""),
+                method: .PUT,
+                body: sharedBusinessCardDto)
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthorized (401).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsUpdateByThirdPartyActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/SharedBusinessCardsController/SharedBusinessCardsUpdateByThirdPartyActionTests.swift
@@ -1,0 +1,60 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("SharedBusinessCards (PUT /shared-business-cards/:id/third-party)", .serialized, .tags(.sharedBusinessCards))
+    struct SharedBusinessCardsUpdateByThirdPartyActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test("Shared business card should be returned for correct code")
+        func sharedBusinessCardShouldBeReturnedForCorrectCode() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "wictorgawol")
+            let businessCard = try await application.createBusinessCard(userId: user.requireID(), title: "Title")
+            let sharedBusinessCard = try await application.createSharedBusinessCard(businessCardId: businessCard.requireID(), title: "Title #1", thirdPartyName: "Marcin")
+            let updateRequest = SharedBusinessCardUpdateRequestDto(thirdPartyName: "Marcin Doe", thirdPartyEmail: "mdoe@example.com", sharedCardUrl: "https://localhost.com")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/shared-business-cards/" + sharedBusinessCard.code + "/third-party",
+                method: .PUT,
+                body: updateRequest
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.ok, "Response http status code should be ok (200).")
+            let sharedBusinessCardFromDatabase = try await application.getSharedBusinessCard(businessCardId: businessCard.requireID())
+            #expect(sharedBusinessCardFromDatabase.first?.thirdPartyName == "Marcin Doe", "Third party name should be updated.")
+            #expect(sharedBusinessCardFromDatabase.first?.thirdPartyEmail == "mdoe@example.com", "Third party name should be updated.")
+        }
+        
+        @Test("Not found should be returned for wrong code")
+        func notFoundShouldBeReturnedForWrongId() async throws {
+            // Arrange.
+            let updateRequest = SharedBusinessCardUpdateRequestDto(thirdPartyName: "Marcin Doe", thirdPartyEmail: "mdoe@example.com", sharedCardUrl: "https://localhost.com")
+
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/shared-business-cards/512/third-party",
+                method: .PUT,
+                body: updateRequest)
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.notFound, "Response http status code should be notFound (404).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/Tags.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/Tags.swift
@@ -13,6 +13,7 @@ extension Tag {
     @Tag static var archives: Tag
     @Tag static var articles: Tag
     @Tag static var atom: Tag
+    @Tag static var businessCards: Tag
     @Tag static var shared: Tag
     @Tag static var attachments: Tag
     @Tag static var authClients: Tag
@@ -43,6 +44,7 @@ extension Tag {
     @Tag static var rules: Tag
     @Tag static var rss: Tag
     @Tag static var search: Tag
+    @Tag static var sharedBusinessCards: Tag
     @Tag static var settings: Tag
     @Tag static var statuses: Tag
     @Tag static var timelines: Tag

--- a/Tests/VernissageServerTests/Helpers/Extensions/BusinessCard.swift
+++ b/Tests/VernissageServerTests/Helpers/Extensions/BusinessCard.swift
@@ -1,0 +1,27 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import VaporTesting
+import Fluent
+
+extension Application {
+    func createBusinessCard(userId: Int64, title: String) async throws -> BusinessCard {
+        let id = await ApplicationManager.shared.generateId()
+        let businessCard = BusinessCard(id: id, userId: userId, title: title, color1: "#ffffff", color2: "#FF00FF", color3: "#000000")
+        try await businessCard.save(on: self.db)
+        
+        return businessCard
+    }
+    
+    func getBusinessCard(userId: Int64) async throws -> BusinessCard? {
+        return try await BusinessCard.query(on: self.db)
+            .with(\.$user)
+            .with(\.$businessCardFields)
+            .filter(\.$user.$id == userId)
+            .first()
+    }
+}

--- a/Tests/VernissageServerTests/Helpers/Extensions/SharedBusinessCard.swift
+++ b/Tests/VernissageServerTests/Helpers/Extensions/SharedBusinessCard.swift
@@ -1,0 +1,36 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import VaporTesting
+import Fluent
+
+extension Application {
+    func createSharedBusinessCard(businessCardId: Int64, title: String, thirdPartyName: String, revokedAt: Date? = nil) async throws -> SharedBusinessCard {
+        let id = await ApplicationManager.shared.generateId()
+        let code = String.createRandomString(length: 64)
+        let businessCard = SharedBusinessCard(id: id,
+                                              businessCardId: businessCardId,
+                                              code: code,
+                                              title: title,
+                                              thirdPartyName: thirdPartyName)
+        
+        if let revokedAt {
+            businessCard.revokedAt = revokedAt
+        }
+        
+        try await businessCard.save(on: self.db)
+        
+        return businessCard
+    }
+    
+    func getSharedBusinessCard(businessCardId: Int64) async throws -> [SharedBusinessCard] {
+        return try await SharedBusinessCard.query(on: self.db)
+            .with(\.$messages)
+            .filter(\.$businessCard.$id == businessCardId)
+            .all()
+    }
+}

--- a/Tests/VernissageServerTests/Helpers/Mocks/MockEmailsService.swift
+++ b/Tests/VernissageServerTests/Helpers/Mocks/MockEmailsService.swift
@@ -19,5 +19,8 @@ final class MockEmailsService: EmailsServiceType {
     
     func dispatchArchiveReadyEmail(archive: Archive, on context: ExecutionContext) async throws {
     }
+    
+    func dispatchSharedBusinessCardEmail(sharedBusinessCard: SharedBusinessCard, sharedCardUrl: String, on context: ExecutionContext) async throws {
+    }
 }
 


### PR DESCRIPTION
These changes introduce a new feature that allows users to create their own business cards. The business card can then be shared with people in public spaces. Such individuals (provided they have a specially generated URL) can send messages to the photographer. The photographer can also reply to them. These individuals can save the URL to their contacts (thanks to the option to export the business card as a VCF file), and if they agree to provide an email address, they will also receive a link to the shared business card via email.

The entire functionality is designed for communication with unknown people who are photographed in public places and who would like to receive their photos. Most of the time, they do not have accounts beyond platforms like Instagram or Facebook, and sharing one’s personal email address or phone number is not an optimal solution.