### PR TITLE
Suppress missing attachments errors

### DIFF
--- a/Sources/ActivityPubKit/Entities/PersonDto.swift
+++ b/Sources/ActivityPubKit/Entities/PersonDto.swift
@@ -168,7 +168,7 @@ extension PersonDto: Codable {
         self.summary = try values.decodeIfPresent(String.self, forKey: .summary)
         self.url = try values.decode(String.self, forKey: .url)
         self.alsoKnownAs = try values.decodeIfPresent([String].self, forKey: .alsoKnownAs)
-        self.manuallyApprovesFollowers = try values.decode(Bool.self, forKey: .manuallyApprovesFollowers)
+        self.manuallyApprovesFollowers = try values.decodeIfPresent(Bool.self, forKey: .manuallyApprovesFollowers) ?? false
         self.publicKey = try values.decode(PersonPublicKeyDto.self, forKey: .publicKey)
         self.icon = try values.decodeIfPresent(PersonImageDto.self, forKey: .icon)
         self.image = try values.decodeIfPresent(PersonImageDto.self, forKey: .image)

--- a/Tests/ActivityPubKitTests/ActivityDtoDeserialization.swift
+++ b/Tests/ActivityPubKitTests/ActivityDtoDeserialization.swift
@@ -233,6 +233,46 @@ struct ActivityDtoDeserialization {
 }
 """
     
+    private let personCase08 =
+"""
+{
+    "@context": [
+        "https://w3id.org/security/v1",
+        "https://www.w3.org/ns/activitystreams"
+    ],
+    "attachment": [],
+    "endpoints": {
+        "sharedInbox": "https://example.com/shared/inbox"
+    },
+    "followers": "https://example.com/actors/johndoe/followers",
+    "following": "https://example.com/actors/johndoe/following",
+    "icon": {
+        "mediaType": "image/jpeg",
+        "type": "Image",
+        "url": "https://s3.eu-central-1.amazonaws.com/instance/039ebf33d1664d5d849574d0e7191354.jpg"
+    },
+    "id": "https://example.com/actors/johndoe",
+    "image": {
+        "mediaType": "image/jpeg",
+        "type": "Image",
+        "url": "https://s3.eu-central-1.amazonaws.com/instance/2ef4a0f69d0e410ba002df2212e2b63c.jpg"
+    },
+    "inbox": "https://example.com/actors/johndoe/inbox",
+    "name": "John Doe",
+    "outbox": "https://example.com/actors/johndoe/outbox",
+    "preferredUsername": "johndoe",
+    "publicKey": {
+        "id": "https://example.com/actors/johndoe#main-key",
+        "owner": "https://example.com/actors/johndoe",
+        "publicKeyPem": "-----BEGIN PUBLIC KEY-----AAAAA-----END PUBLIC KEY-----"
+    },
+    "summary": "Test summary",
+    "tag": [],
+    "type": "Person",
+    "url": "https://example.com/@johndoe"
+}
+"""
+    
     private let statusCase01 =
 """
 {
@@ -759,6 +799,17 @@ struct ActivityDtoDeserialization {
         #expect(personDto.attachment?[1].name == "GITHUB")
         #expect(personDto.attachment?[1].value == "https://github.com/johndoe")
         #expect(personDto.attachment?[1].type == "PropertyValue")
+    }
+    
+    
+    @Test("JSON withouth manuallyApprovesFollowers field in person should deserialize")
+    func jsonWithoutManuallyApprovesFollowersFIeldInPersonShouldDeserialized() throws {
+
+        // Act.
+        let personDto = try self.decoder.decode(PersonDto.self, from: personCase08.data(using: .utf8)!)
+
+        // Assert.
+        #expect(personDto.manuallyApprovesFollowers == false)
     }
     
     @Test("JSON with create status1 should deserialize")


### PR DESCRIPTION
Suppress missing attachments errors and fix Person decoding without `manuallyApprovesFollowers` property.