### PR TITLE
Fix bridgy webfinger

### DIFF
--- a/Sources/ActivityPubKit/Entities/ComplexType.swift
+++ b/Sources/ActivityPubKit/Entities/ComplexType.swift
@@ -103,3 +103,20 @@ extension ComplexType: Equatable {
         }
     }
 }
+
+extension ComplexType<String> {
+    public func values() -> [String] {
+        var values: [String] = []
+        
+        switch self {
+        case .single(let singleValue):
+            values.append(singleValue)
+        case .multiple(let multipleValues):
+            for singleValue in multipleValues {
+                values.append(singleValue)
+            }
+        }
+        
+        return values
+    }
+}

--- a/Sources/ActivityPubKit/Entities/PersonDto.swift
+++ b/Sources/ActivityPubKit/Entities/PersonDto.swift
@@ -15,12 +15,12 @@ public struct PersonDto {
     public let preferredUsername: String
     public let name: String
     public let summary: String?
-    public let url: String
+    public let url: ComplexType<String>
     public let alsoKnownAs: [String]?
     public let manuallyApprovesFollowers: Bool
     public let publicKey: PersonPublicKeyDto
-    public let icon: PersonImageDto?
-    public let image: PersonImageDto?
+    public let icon: ComplexType<PersonImageDto>?
+    public let image: ComplexType<PersonImageDto>?
     public let endpoints: PersonEndpointsDto
     public let attachment: [PersonAttachmentDto]?
     public let tag: [PersonHashtagDto]?
@@ -62,12 +62,12 @@ public struct PersonDto {
         self.preferredUsername = preferredUsername
         self.name = name
         self.summary = summary
-        self.url = url
+        self.url = .single(url)
         self.alsoKnownAs = alsoKnownAs
         self.manuallyApprovesFollowers = manuallyApprovesFollowers
         self.publicKey = publicKey
-        self.icon = icon
-        self.image = image
+        self.icon = if let icon { .single(icon) } else { nil }
+        self.image = if let image { .single(image) } else { nil }
         self.endpoints = endpoints
         self.attachment = attachment
         self.tag = tag
@@ -101,7 +101,7 @@ public struct PersonDto {
         self.preferredUsername = preferredUsername
         self.name = ""
         self.summary = nil
-        self.url = url
+        self.url = .single(url)
         self.alsoKnownAs = nil
         self.manuallyApprovesFollowers = manuallyApprovesFollowers
         self.publicKey = publicKey
@@ -166,12 +166,12 @@ extension PersonDto: Codable {
         self.preferredUsername = try values.decode(String.self, forKey: .preferredUsername)
         self.name = try values.decodeIfPresent(String.self, forKey: .name) ?? ""
         self.summary = try values.decodeIfPresent(String.self, forKey: .summary)
-        self.url = try values.decode(String.self, forKey: .url)
+        self.url = try values.decode(ComplexType<String>.self, forKey: .url)
         self.alsoKnownAs = try values.decodeIfPresent([String].self, forKey: .alsoKnownAs)
         self.manuallyApprovesFollowers = try values.decodeIfPresent(Bool.self, forKey: .manuallyApprovesFollowers) ?? false
         self.publicKey = try values.decode(PersonPublicKeyDto.self, forKey: .publicKey)
-        self.icon = try values.decodeIfPresent(PersonImageDto.self, forKey: .icon)
-        self.image = try values.decodeIfPresent(PersonImageDto.self, forKey: .image)
+        self.icon = try values.decodeIfPresent(ComplexType<PersonImageDto>.self, forKey: .icon)
+        self.image = try values.decodeIfPresent(ComplexType<PersonImageDto>.self, forKey: .image)
         self.endpoints = try values.decode(PersonEndpointsDto.self, forKey: .endpoints)
         self.attachment = try values.decodeIfPresent([PersonAttachmentDto].self, forKey: .attachment)
         self.tag = try values.decodeIfPresent([PersonHashtagDto].self, forKey: .tag)

--- a/Sources/ActivityPubKit/Entities/PersonImageDto.swift
+++ b/Sources/ActivityPubKit/Entities/PersonImageDto.swift
@@ -23,3 +23,26 @@ public struct PersonImageDto {
 
 extension PersonImageDto: Codable { }
 extension PersonImageDto: Sendable { }
+
+extension PersonImageDto: Equatable {
+    public static func == (lhs: PersonImageDto, rhs: PersonImageDto) -> Bool {
+        return lhs.url == rhs.url && lhs.mediaType == rhs.mediaType
+    }
+}
+
+extension ComplexType<PersonImageDto> {
+    public func images() -> [PersonImageDto] {
+        var images: [PersonImageDto] = []
+        
+        switch self {
+        case .single(let imageDto):
+            images.append(imageDto)
+        case .multiple(let imageDtos):
+            for imageDto in imageDtos {
+                images.append(imageDto)
+            }
+        }
+        
+        return images
+    }
+}

--- a/Sources/ActivityPubKit/Errors/PersonError.swift
+++ b/Sources/ActivityPubKit/Errors/PersonError.swift
@@ -1,0 +1,22 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2024 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Foundation
+
+public enum PersonError: Error {
+    case missingUrl
+}
+
+extension PersonError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .missingUrl:
+            return NSLocalizedString("person.error.missingUrl",
+                                     bundle: Bundle.module,
+                                     comment: "Missing person URL. At least one person URL is required.")
+        }
+    }
+}

--- a/Sources/ActivityPubKit/Networking/TargetType.swift
+++ b/Sources/ActivityPubKit/Networking/TargetType.swift
@@ -52,6 +52,18 @@ extension [Header: String] {
         return selfCopy
     }
     
+    var acceptApplicationLdJson: [Header: String] {
+        var selfCopy = self
+        selfCopy[.accept] = "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\""
+        return selfCopy
+    }
+
+    var acceptApplicationActivityJson: [Header: String] {
+        var selfCopy = self
+        selfCopy[.accept] = "application/activity+json"
+        return selfCopy
+    }
+    
     func host(_ host: String) -> [Header: String] {
         var selfCopy = self
         selfCopy[.host] = host
@@ -95,7 +107,7 @@ extension [Header: String] {
     func signature(actorId: String, privateKeyPem: String, body: Data?, httpMethod: Method, httpPath: String, userAgent: String, host: String) -> [Header: String] {
         // Add all headers required for generating signature into the dictionary.
         var selfCopy = self
-            .acceptApplicationJson
+            .acceptApplicationActivityJson
             .host(host)
             .date
             .digest(body)

--- a/Sources/ActivityPubKit/Resources/en.lproj/Localizable.strings
+++ b/Sources/ActivityPubKit/Resources/en.lproj/Localizable.strings
@@ -2,3 +2,4 @@
 "global.error.notSuccessResponse" = "Server response code: %@. Server response body: %@.";
 "global.error.jsonDecodeError" = "JSON from response cannot be decoded.";
 "global.error.unknownError" = "Unexpected error.";
+"person.error.missingUrl" = "Missing person URL. At least one person URL is required.";

--- a/Sources/ActivityPubKit/Resources/pl.lproj/Localizable.strings
+++ b/Sources/ActivityPubKit/Resources/pl.lproj/Localizable.strings
@@ -2,3 +2,4 @@
 "global.error.notSuccessResponse" = "Kod odpowiedzi serwera: %@. Zawartość odpowiedzi: %@.";
 "global.error.jsonDecodeError" = "JSON z serwera nie może być zamienieony na obiekt.";
 "global.error.unknownError" = "Nieznany błąd serwera.";
+"person.error.missingUrl" = "Brakuje URL w obiekcie użytkownika. Przynajmniej jeden URL jest wymagany.";

--- a/Sources/VernissageServer/Application+Configure.swift
+++ b/Sources/VernissageServer/Application+Configure.swift
@@ -354,6 +354,7 @@ extension Application {
         
         self.migrations.add(ArticleFileInfo.CreateArticleFileInfos())
         self.migrations.add(Article.AddMainArticleFileInfo())
+        self.migrations.add(User.AddUserTypeField())
         
         try await self.autoMigrate()
     }

--- a/Sources/VernissageServer/DataTransferObjects/UserDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/UserDto.swift
@@ -8,6 +8,7 @@ import Vapor
 
 struct UserDto: Codable {
     var id: String?
+    var type: UserTypeDto
     var url: String?
     var isLocal: Bool
     var isBlocked: Bool?
@@ -38,6 +39,7 @@ struct UserDto: Codable {
     
     enum CodingKeys: String, CodingKey {
         case id
+        case type
         case url
         case isLocal
         case isBlocked
@@ -68,6 +70,7 @@ struct UserDto: Codable {
     }
     
     init(id: String? = nil,
+         type: UserTypeDto = .person,
          url: String? = nil,
          isLocal: Bool,
          isBlocked: Bool? = nil,
@@ -93,6 +96,7 @@ struct UserDto: Codable {
          baseAddress: String,
          featured: Bool? = nil) {
         self.id = id
+        self.type = type
         self.url = url
         self.isLocal = isLocal
         self.isBlocked = isBlocked
@@ -127,6 +131,7 @@ struct UserDto: Codable {
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         id = try values.decodeIfPresent(String.self, forKey: .id)
+        type = try values.decodeIfPresent(UserTypeDto.self, forKey: .type) ?? .person
         url = try values.decodeIfPresent(String.self, forKey: .url)
         isLocal = try values.decodeIfPresent(Bool.self, forKey: .isLocal) ?? true
         isBlocked = try values.decodeIfPresent(Bool.self, forKey: .isBlocked) ?? false
@@ -158,6 +163,7 @@ struct UserDto: Codable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(type, forKey: .type)
         try container.encodeIfPresent(url, forKey: .url)
         try container.encodeIfPresent(isLocal, forKey: .isLocal)
         try container.encodeIfPresent(isBlocked, forKey: .isBlocked)
@@ -200,6 +206,7 @@ extension UserDto {
         
         self.init(
             id: user.stringId(),
+            type: UserTypeDto.from(user.type),
             url: user.url,
             isLocal: user.isLocal,
             userName: user.userName,

--- a/Sources/VernissageServer/DataTransferObjects/UserTypeDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/UserTypeDto.swift
@@ -1,0 +1,65 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+
+enum UserTypeDto: String {
+    /// Not recognized actor type.
+    case unknown
+
+    /// Represents an individual person.
+    case person
+    
+    /// Describes a software application.
+    case application
+    
+    /// Represents a formal or informal collective of Actors.
+    case group
+    
+    /// Represents an organization.
+    case organization
+    
+    /// Represents a service of any kind.
+    case service
+}
+
+extension UserTypeDto {
+    public func translate() -> UserType {
+        switch self {
+        case .unknown:
+            return UserType.unknown
+        case .person:
+            return UserType.person
+        case .application:
+            return UserType.application
+        case .group:
+            return UserType.group
+        case .organization:
+            return UserType.organization
+        case .service:
+            return UserType.service
+        }
+    }
+    
+    public static func from(_ userType: UserType) -> UserTypeDto {
+        switch userType {
+        case .unknown:
+            return UserTypeDto.unknown
+        case .person:
+            return UserTypeDto.person
+        case .application:
+            return UserTypeDto.application
+        case .group:
+            return UserTypeDto.group
+        case .organization:
+            return UserTypeDto.organization
+        case .service:
+            return UserTypeDto.service
+        }
+    }
+}
+
+extension UserTypeDto: Content { }

--- a/Sources/VernissageServer/Extensions/Application+Seed.swift
+++ b/Sources/VernissageServer/Extensions/Application+Seed.swift
@@ -668,6 +668,7 @@ extension Application {
             
             let newUserId = self.services.snowflakeService.generate()
             let user = User(id: newUserId,
+                            type: .person,
                             url: "\(baseAddress)/@admin",
                             isLocal: true,
                             userName: "admin",

--- a/Sources/VernissageServer/Migrations/CreateUsers.swift
+++ b/Sources/VernissageServer/Migrations/CreateUsers.swift
@@ -274,4 +274,20 @@ extension User {
                 .update()
         }
     }
+    
+    struct AddUserTypeField: AsyncMigration {
+        func prepare(on database: Database) async throws {
+            try await database
+                .schema(User.schema)
+                .field("userType", .int, .required, .sql(.default(1)))
+                .update()
+        }
+        
+        func revert(on database: Database) async throws {
+            try await database
+                .schema(User.schema)
+                .deleteField("userType")
+                .update()
+        }
+    }
 }

--- a/Sources/VernissageServer/Models/User.swift
+++ b/Sources/VernissageServer/Models/User.swift
@@ -14,6 +14,9 @@ final class User: Model, @unchecked Sendable {
     
     @ID(custom: .id, generatedBy: .user)
     var id: Int64?
+
+    @Field(key: "userType")
+    var type: UserType
     
     @Field(key: "url")
     var url: String?
@@ -168,6 +171,7 @@ final class User: Model, @unchecked Sendable {
     init() { }
     
     convenience init(id: Int64,
+                     type: UserType,
                      url: String,
                      isLocal: Bool,
                      userName: String,
@@ -205,6 +209,7 @@ final class User: Model, @unchecked Sendable {
         self.init()
 
         self.id = id
+        self.type = type
         self.url = url
         self.isLocal = isLocal
         self.userName = userName
@@ -267,6 +272,7 @@ extension User {
                      publicKey: String) {
         self.init(
             id: id,
+            type: .person,
             url: url,
             isLocal: true,
             userName: registerUserDto.userName,
@@ -302,6 +308,7 @@ extension User {
                      publicKey: String) {
         self.init(
             id: id,
+            type: .person,
             url: url,
             isLocal: true,
             userName: oauthUser.email,

--- a/Sources/VernissageServer/Models/UserType.swift
+++ b/Sources/VernissageServer/Models/UserType.swift
@@ -1,0 +1,48 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Foundation
+import ActivityPubKit
+
+/// Actor types are Object types that are capable of performing activities.
+enum UserType: Int, Codable {
+    /// Not recognized actor type.
+    case unknown = 0
+
+    /// Represents an individual person.
+    case person = 1
+    
+    /// Describes a software application.
+    case application = 2
+    
+    /// Represents a formal or informal collective of Actors.
+    case group = 3
+    
+    /// Represents an organization.
+    case organization = 4
+    
+    /// Represents a service of any kind.
+    case service = 5
+}
+
+extension PersonDto {
+    func getUserType() -> UserType {
+        switch self.type.uppercased() {
+        case "PERSON":
+            return .person
+        case "APPLICATION":
+            return .application
+        case "GROUP":
+            return .group
+        case "ORGANIZATION":
+            return .organization
+        case "SERVICE":
+            return .service
+        default:
+            return .unknown
+        }
+    }
+}

--- a/Sources/VernissageServer/Services/ArchivesService.swift
+++ b/Sources/VernissageServer/Services/ArchivesService.swift
@@ -174,7 +174,7 @@ final class ArchivesService: ArchivesServiceType {
     }
 
     private func saveAvatarFile(archiveId: Int64, personDto: PersonDto, on context: QueueContext) async throws {
-        if let icon = personDto.icon {
+        if let icon = personDto.icon?.images().first {
             context.logger.info("Creating avatar image file for archive: '\(archiveId)'.")
             let temporaryFileService = context.application.services.temporaryFileService
 
@@ -190,7 +190,7 @@ final class ArchivesService: ArchivesServiceType {
     }
     
     private func saveHeaderFile(archiveId: Int64, personDto: PersonDto, on context: QueueContext) async throws {
-        if let icon = personDto.image {
+        if let icon = personDto.image?.images().first {
             context.logger.info("Creating header image file for archive: '\(archiveId)'.")
             let temporaryFileService = context.application.services.temporaryFileService
             

--- a/Sources/VernissageServer/Services/SearchService.swift
+++ b/Sources/VernissageServer/Services/SearchService.swift
@@ -385,7 +385,7 @@ final class SearchService: SearchServiceType {
     }
     
     private func downloadProfileImage(personProfile: PersonDto, on context: ExecutionContext) async -> String? {
-        guard let icon = personProfile.icon else {
+        guard let icon = personProfile.icon?.images().first else {
             return nil
         }
         
@@ -401,7 +401,7 @@ final class SearchService: SearchServiceType {
     }
     
     private func downloadHeaderImage(personProfile: PersonDto, on context: ExecutionContext) async -> String? {
-        guard let image = personProfile.image else {
+        guard let image = personProfile.image?.images().first else {
             return nil
         }
         

--- a/Sources/VernissageServer/Services/UsersService.swift
+++ b/Sources/VernissageServer/Services/UsersService.swift
@@ -490,10 +490,20 @@ final class UsersService: UsersServiceType {
         return user
     }
     
-    func update(user: User, basedOn person: PersonDto, withAvatarFileName avatarFileName: String?, withHeaderFileName headerFileName: String?, on context: ExecutionContext) async throws -> User {
-        let remoteUserName = "\(person.preferredUsername)@\(person.url.host)"
+    func update(user: User,
+                basedOn person: PersonDto,
+                withAvatarFileName avatarFileName: String?,
+                withHeaderFileName headerFileName: String?,
+                on context: ExecutionContext) async throws -> User {
 
-        user.url = person.url
+        let urls = person.url.values()
+        guard let personUrl = urls.first else {
+            throw PersonError.missingUrl
+        }
+        
+        let remoteUserName = "\(person.preferredUsername)@\(personUrl)"
+
+        user.url = personUrl
         user.userName = remoteUserName
         user.account = remoteUserName
         user.name = person.clearName()
@@ -518,11 +528,18 @@ final class UsersService: UsersServiceType {
     }
     
     func create(basedOn person: PersonDto, withAvatarFileName avatarFileName: String?, withHeaderFileName headerFileName: String?, on context: ExecutionContext) async throws -> User {
-        let remoteUserName = "\(person.preferredUsername)@\(person.url.host)"
+        
+        let urls = person.url.values()
+        guard let personUrl = urls.first else {
+            throw PersonError.missingUrl
+        }
+        
+        let remoteUserName = "\(person.preferredUsername)@\(personUrl.host)"
         
         let newUserId = context.services.snowflakeService.generate()
         let user = User(id: newUserId,
-                        url: person.url,
+                        type: person.getUserType(),
+                        url: personUrl,
                         isLocal: false,
                         userName: remoteUserName,
                         account: remoteUserName,

--- a/Sources/VernissageServer/VernissageServer.docc/VernissageServer.md
+++ b/Sources/VernissageServer/VernissageServer.docc/VernissageServer.md
@@ -127,6 +127,7 @@ can be added by the system administrator.
 - ``ActivityPubUnreblogDto``
 - ``AttachmentDescriptionDto``
 - ``ArticleDto``
+- ``ArticleFileInfoDto``
 - ``ArticleVisibilityDto``
 - ``ArchiveDto``
 - ``ArchiveStatusDto``
@@ -134,6 +135,7 @@ can be added by the system administrator.
 - ``AuthClientDto``
 - ``AttachmentHashtagDto``
 - ``BooleanResponseDto``
+- ``BusinessCardAvatarDto``
 - ``BusinessCardDto``
 - ``BusinessCardFieldDto``
 - ``CategoryDto``
@@ -210,6 +212,7 @@ can be added by the system administrator.
 - ``UserDto``
 - ``UserMuteRequestDto``
 - ``UserSettingDto``
+- ``UserTypeDto``
 - ``WebPushDto``
 
 ### Authentication
@@ -354,6 +357,7 @@ can be added by the system administrator.
 - ``ApplicationSettings``
 - ``Attachment``
 - ``Article``
+- ``ArticleFileInfo``
 - ``ArticleRead``
 - ``ArticleVisibility``
 - ``ArticleVisibilityType``
@@ -424,6 +428,7 @@ can be added by the system administrator.
 - ``UserSetting``
 - ``UserStatus``
 - ``UserStatusType``
+- ``UserType``
 
 ### Queue Drivers
 

--- a/Tests/ActivityPubKitTests/ActivityDtoDeserialization.swift
+++ b/Tests/ActivityPubKitTests/ActivityDtoDeserialization.swift
@@ -272,6 +272,71 @@ struct ActivityDtoDeserialization {
     "url": "https://example.com/@johndoe"
 }
 """
+    private let personCase09 =
+"""
+{
+   "@context":[
+      "https://www.w3.org/ns/activitystreams",
+      "https://purl.archive.org/miscellany",
+      "https://w3id.org/security/v1",
+      {
+         "alsoKnownAs":{
+            "@id":"as:alsoKnownAs",
+            "@type":"@id"
+         }
+      }
+   ],
+   "alsoKnownAs":[
+      "https://bsky.brid.gy/",
+      "https://fed.brid.gy/"
+   ],
+   "endpoints":{
+      "sharedInbox":"https://bsky.brid.gy/ap/sharedInbox"
+   },
+   "followers":"https://bsky.brid.gy/bsky.brid.gy/followers",
+   "following":"https://bsky.brid.gy/bsky.brid.gy/following",
+   "icon":[
+      {
+         "name":"Bridgy Fed for Bluesky",
+         "type":"Image",
+         "url":"https://fed.brid.gy/static/bridgy_logo_square.jpg"
+      },
+      {
+         "name":"Bridgy Fed for Bluesky",
+         "type":"Image",
+         "url":"https://fed.brid.gy/static/bridgy_logo2.jpg"
+      }
+   ],
+   "id":"https://bsky.brid.gy/bsky.brid.gy",
+   "image":[
+      {
+         "type":"Image",
+         "url":"https://fed.brid.gy/static/bridgy_fed_banner.png"
+      },
+      {
+         "name":"Bridgy Fed for Bluesky",
+         "type":"Image",
+         "url":"https://fed.brid.gy/static/bridgy_logo_square.jpg"
+      }
+   ],
+   "inbox":"https://bsky.brid.gy/bsky.brid.gy/inbox",
+   "manuallyApprovesFollowers":false,
+   "name":"Bridgy Fed for Bluesky",
+   "outbox":"https://bsky.brid.gy/bsky.brid.gy/outbox",
+   "preferredUsername":"bsky.brid.gy",
+   "publicKey":{
+      "id":"https://bsky.brid.gy/bsky.brid.gy#key",
+      "owner":"https://bsky.brid.gy/bsky.brid.gy",
+      "publicKeyPem":"-----BEGIN PUBLIC KEY-----AAAAA-----END PUBLIC KEY-----"
+   },
+   "summary":"<p><a href='https://fed.brid.gy/'>Bridgy Fed</a> bot user for <a href='https://bsky.social/'>Bluesky</a>. To bridge your fediverse account to Bluesky, follow this account. <a href='https://fed.brid.gy/docs'>More info here.</a><p>After you follow this account, it will follow you back. Accept its follow to make sure your fediverse posts get sent to the bridge and make it into Bluesky.<p>To ask a Bluesky user to bridge their account, DM their handle (eg snarfed.bsky.social) to this account.</p>",
+   "type":"Service",
+   "url":[
+      "https://bsky.brid.gy/",
+      "https://fed.brid.gy/"
+   ]
+}
+"""
     
     private let statusCase01 =
 """
@@ -807,6 +872,16 @@ struct ActivityDtoDeserialization {
 
         // Act.
         let personDto = try self.decoder.decode(PersonDto.self, from: personCase08.data(using: .utf8)!)
+
+        // Assert.
+        #expect(personDto.manuallyApprovesFollowers == false)
+    }
+    
+    @Test("JSON with complex properties from brid.gy should deserialize")
+    func jsonWithComplexPropertiesFromBridgyShouldDeserialized() throws {
+
+        // Act.
+        let personDto = try self.decoder.decode(PersonDto.self, from: personCase09.data(using: .utf8)!)
 
         // Assert.
         #expect(personDto.manuallyApprovesFollowers == false)

--- a/Tests/VernissageServerTests/AcceptanceTests/UsersController/UsersReadActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/UsersController/UsersReadActionTests.swift
@@ -35,6 +35,7 @@ extension ControllersTests {
             
             // Assert.
             #expect(userDto.id == user.stringId(), "Property 'id' should be equal.")
+            #expect(userDto.type == .person, "Property 'type' should be equal.")
             #expect(userDto.account == user.account, "Property 'userName' should be equal.")
             #expect(userDto.userName == user.userName, "Property 'userName' should be equal.")
             #expect(userDto.email == user.email, "Property 'email' should be equal.")

--- a/Tests/VernissageServerTests/Helpers/Extensions/User.swift
+++ b/Tests/VernissageServerTests/Helpers/Extensions/User.swift
@@ -32,6 +32,7 @@ extension Application {
         let (privateKey, publicKey) = generateKeys ? try self.services.cryptoService.generateKeys() : (nil, nil)
         let id = await ApplicationManager.shared.generateId()
         let user = User(id: id,
+                        type: .person,
                         url: "http://localhost:8080/@\(userName)",
                         isLocal: isLocal,
                         userName: userName,


### PR DESCRIPTION
Two main improvements have been introduced. ActivityPub requests now send the `Accept` header as `application/activity+json` (previously it was `application/json`), which caused some fediverse applications not to return the user profile correctly. Additionally, a new field has been added to the `Users` table: `type`. It can take the following values: `person`, `application`, `group`, `organization`, or `service`.