### PR TITLE
Add publishedAt to Person/Note (and UserDto and StatusDto)

### DIFF
--- a/Sources/ActivityPubKit/Entities/ContextDto.swift
+++ b/Sources/ActivityPubKit/Entities/ContextDto.swift
@@ -195,7 +195,7 @@ extension ContextDto {
             ContextDto(value: "https://www.w3.org/ns/activitystreams"),
             ContextDto(manuallyApprovesFollowers: "as:manuallyApprovesFollowers",
                        toot: "http://joinmastodon.org/ns#",
-                       schema: "http://schema.org#",
+                       schema: "https://schema.org",
                        propertyValue: "schema:PropertyValue",
                        alsoKnownAs: AlsoKnownAs(id: "as:alsoKnownAs", type: "@id"))
         ])
@@ -205,7 +205,7 @@ extension ContextDto {
         .multiple([
             ContextDto(value: "https://www.w3.org/ns/activitystreams"),
             ContextDto(toot: "http://joinmastodon.org/ns#",
-                       schema: "http://schema.org#",
+                       schema: "https://schema.org",
                        blurhash: "toot:blurhash",
                        photos: "https://joinvernissage.org/ns#",
                        geonameId: "photos:geonameId",

--- a/Sources/ActivityPubKit/Entities/PersonDto.swift
+++ b/Sources/ActivityPubKit/Entities/PersonDto.swift
@@ -18,6 +18,7 @@ public struct PersonDto {
     public let url: ComplexType<String>
     public let alsoKnownAs: [String]?
     public let manuallyApprovesFollowers: Bool
+    public let published: String?
     public let publicKey: PersonPublicKeyDto
     public let icon: ComplexType<PersonImageDto>?
     public let image: ComplexType<PersonImageDto>?
@@ -36,6 +37,7 @@ public struct PersonDto {
                 url: String,
                 alsoKnownAs: [String]?,
                 manuallyApprovesFollowers: Bool,
+                published: String?,
                 publicKey: PersonPublicKeyDto,
                 icon: PersonImageDto?,
                 image: PersonImageDto?,
@@ -56,6 +58,7 @@ public struct PersonDto {
         self.url = .single(url)
         self.alsoKnownAs = alsoKnownAs
         self.manuallyApprovesFollowers = manuallyApprovesFollowers
+        self.published = published
         self.publicKey = publicKey
         self.icon = if let icon { .single(icon) } else { nil }
         self.image = if let image { .single(image) } else { nil }
@@ -70,6 +73,7 @@ public struct PersonDto {
                 preferredUsername: String,
                 url: String,
                 manuallyApprovesFollowers: Bool,
+                published: String?,
                 endpoints: PersonEndpointsDto,
                 publicKey: PersonPublicKeyDto
     ) {
@@ -86,6 +90,7 @@ public struct PersonDto {
         self.url = .single(url)
         self.alsoKnownAs = nil
         self.manuallyApprovesFollowers = manuallyApprovesFollowers
+        self.published = published
         self.publicKey = publicKey
         self.icon = nil
         self.image = nil
@@ -107,6 +112,7 @@ public struct PersonDto {
         case summary
         case url
         case manuallyApprovesFollowers
+        case published
         case publicKey
         case icon
         case image
@@ -151,6 +157,7 @@ extension PersonDto: Codable {
         self.url = try values.decode(ComplexType<String>.self, forKey: .url)
         self.alsoKnownAs = try values.decodeIfPresent([String].self, forKey: .alsoKnownAs)
         self.manuallyApprovesFollowers = try values.decodeIfPresent(Bool.self, forKey: .manuallyApprovesFollowers) ?? false
+        self.published = try values.decodeIfPresent(String.self, forKey: .published)
         self.publicKey = try values.decode(PersonPublicKeyDto.self, forKey: .publicKey)
         self.icon = try values.decodeIfPresent(ComplexType<PersonImageDto>.self, forKey: .icon)
         self.image = try values.decodeIfPresent(ComplexType<PersonImageDto>.self, forKey: .image)
@@ -173,6 +180,7 @@ extension PersonDto: Codable {
         try container.encodeIfPresent(url, forKey: .url)
         try container.encodeIfPresent(alsoKnownAs, forKey: .alsoKnownAs)
         try container.encodeIfPresent(manuallyApprovesFollowers, forKey: .manuallyApprovesFollowers)
+        try container.encodeIfPresent(published, forKey: .published)
         try container.encodeIfPresent(publicKey, forKey: .publicKey)
         try container.encodeIfPresent(icon, forKey: .icon)
         try container.encodeIfPresent(image, forKey: .image)

--- a/Sources/VernissageServer/Application+Configure.swift
+++ b/Sources/VernissageServer/Application+Configure.swift
@@ -356,6 +356,9 @@ extension Application {
         self.migrations.add(Article.AddMainArticleFileInfo())
         self.migrations.add(User.AddUserTypeField())
         
+        self.migrations.add(User.CreatePublishedAt())
+        self.migrations.add(Status.CreatePublishedAt())
+        
         try await self.autoMigrate()
     }
 

--- a/Sources/VernissageServer/Controllers/ActivityPubActorController.swift
+++ b/Sources/VernissageServer/Controllers/ActivityPubActorController.swift
@@ -100,6 +100,7 @@ struct ActivityPubActorController {
                                        preferredUsername: domain,
                                        url: "\(baseAddress)/support",
                                        manuallyApprovesFollowers: true,
+                                       published: user.createdAt?.toISO8601String() ?? Date().toISO8601String(),
                                        endpoints: PersonEndpointsDto(sharedInbox: "\(baseAddress)/shared/inbox"),
                                        publicKey: PersonPublicKeyDto(id: "\(baseAddress)/actor#main-key",
                                                                      owner: "\(baseAddress)/actor",

--- a/Sources/VernissageServer/Controllers/StatusesController.swift
+++ b/Sources/VernissageServer/Controllers/StatusesController.swift
@@ -345,7 +345,8 @@ struct StatusesController {
                             contentWarning: statusRequestDto.contentWarning,
                             commentsDisabled: statusRequestDto.commentsDisabled,
                             replyToStatusId: statusRequestDto.replyToStatusId?.toId(),
-                            mainReplyToStatusId: mainStatus?.id ?? statusRequestDto.replyToStatusId?.toId())
+                            mainReplyToStatusId: mainStatus?.id ?? statusRequestDto.replyToStatusId?.toId(),
+                            publishedAt: Date())
         
         let statusMentions = try await getStatusMentions(status: status, on: request)
         let statusHashtags = try await getStatusHashtags(status: status, on: request)
@@ -1126,7 +1127,8 @@ struct StatusesController {
                             application: request.applicationName,
                             categoryId: nil,
                             visibility: (reblogRequestDto?.visibility ?? .public).translate(),
-                            reblogId: statusId)
+                            reblogId: statusId,
+                            publishedAt: Date())
         
         // Save status and recalculate reblogs count.
         try await status.create(on: request.db)

--- a/Sources/VernissageServer/DataTransferObjects/StatusDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/StatusDto.swift
@@ -31,8 +31,9 @@ final class StatusDto {
     let application: String?
     let activityPubId: String
     let activityPubUrl: String
-    let createdAt: String?
-    let updatedAt: String?
+    let publishedAt: Date?
+    let createdAt: Date?
+    let updatedAt: Date?
     
     enum CodingKeys: String, CodingKey {
         case id
@@ -59,36 +60,40 @@ final class StatusDto {
         case application
         case activityPubId
         case activityPubUrl
+        case publishedAt
         case createdAt
         case updatedAt
     }
     
-    private init(id: String?,
-         isLocal: Bool,
-         note: String?,
-         noteHtml: String?,
-         visibility: StatusVisibilityDto,
-         sensitive: Bool,
-         contentWarning: String? = nil,
-         commentsDisabled: Bool,
-         replyToStatusId: String? = nil,
-         user: UserDto,
-         activityPubId: String,
-         activityPubUrl: String,
-         attachments: [AttachmentDto]? = nil,
-         tags: [HashtagDto]? = nil,
-         reblog: StatusDto? = nil,
-         category: CategoryDto?,
-         application: String?,
-         repliesCount: Int = 0,
-         reblogsCount: Int = 0,
-         favouritesCount: Int = 0,
-         favourited: Bool = false,
-         reblogged: Bool = false,
-         bookmarked: Bool = false,
-         featured: Bool = false,
-         createdAt: String?,
-         updatedAt: String?) {
+    private init(
+        id: String?,
+        isLocal: Bool,
+        note: String?,
+        noteHtml: String?,
+        visibility: StatusVisibilityDto,
+        sensitive: Bool,
+        contentWarning: String? = nil,
+        commentsDisabled: Bool,
+        replyToStatusId: String? = nil,
+        user: UserDto,
+        activityPubId: String,
+        activityPubUrl: String,
+        attachments: [AttachmentDto]? = nil,
+        tags: [HashtagDto]? = nil,
+        reblog: StatusDto? = nil,
+        category: CategoryDto?,
+        application: String?,
+        repliesCount: Int = 0,
+        reblogsCount: Int = 0,
+        favouritesCount: Int = 0,
+        favourited: Bool = false,
+        reblogged: Bool = false,
+        bookmarked: Bool = false,
+        featured: Bool = false,
+        publishedAt: Date?,
+        createdAt: Date?,
+        updatedAt: Date?
+    ) {
         self.id = id
         self.isLocal = isLocal
         self.note = note
@@ -113,6 +118,7 @@ final class StatusDto {
         self.reblog = reblog
         self.category = category
         self.application = application
+        self.publishedAt = publishedAt
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
@@ -143,8 +149,9 @@ final class StatusDto {
         reblog = try values.decodeIfPresent(StatusDto.self, forKey: .reblog)
         category = try values.decodeIfPresent(CategoryDto.self, forKey: .category)
         application = try values.decodeIfPresent(String.self, forKey: .application) ?? ""
-        createdAt = try values.decodeIfPresent(String.self, forKey: .createdAt) ?? ""
-        updatedAt = try values.decodeIfPresent(String.self, forKey: .updatedAt) ?? ""
+        publishedAt = try values.decodeIfPresent(Date.self, forKey: .publishedAt)
+        createdAt = try values.decodeIfPresent(Date.self, forKey: .createdAt)
+        updatedAt = try values.decodeIfPresent(Date.self, forKey: .updatedAt)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -173,6 +180,7 @@ final class StatusDto {
         try container.encodeIfPresent(reblog, forKey: .reblog)
         try container.encodeIfPresent(category, forKey: .category)
         try container.encodeIfPresent(application, forKey: .application)
+        try container.encodeIfPresent(publishedAt, forKey: .publishedAt)
         try container.encodeIfPresent(createdAt, forKey: .createdAt)
         try container.encodeIfPresent(updatedAt, forKey: .updatedAt)
     }
@@ -219,8 +227,9 @@ extension StatusDto {
             reblogged: isReblogged,
             bookmarked: isBookmarked,
             featured: isFeatured,
-            createdAt: status.createdAt?.toISO8601String(),
-            updatedAt: status.updatedAt?.toISO8601String()
+            publishedAt: status.publishedAt,
+            createdAt: status.createdAt,
+            updatedAt: status.updatedAt
         )
     }
 }

--- a/Sources/VernissageServer/DataTransferObjects/UserDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/UserDto.swift
@@ -30,6 +30,7 @@ struct UserDto: Codable {
     var fields: [FlexiFieldDto]?
     var bioHtml: String?
     var lastLoginDate: Date?
+    var publishedAt: Date?
     var createdAt: Date?
     var updatedAt: Date?
     var roles: [String]?
@@ -61,6 +62,7 @@ struct UserDto: Codable {
         case bioHtml
         case activityPubProfile
         case lastLoginDate
+        case publishedAt
         case createdAt
         case updatedAt
         case roles
@@ -91,6 +93,7 @@ struct UserDto: Codable {
          fields: [FlexiFieldDto]? = nil,
          roles: [String]? = nil,
          lastLoginDate: Date? = nil,
+         publishedAt: Date? = nil,
          createdAt: Date? = nil,
          updatedAt: Date? = nil,
          baseAddress: String,
@@ -115,6 +118,7 @@ struct UserDto: Codable {
         self.activityPubProfile = activityPubProfile
         self.bioHtml = self.isLocal ? self.bio?.html(baseAddress: baseAddress, wrapInParagraph: true) : self.bio
         self.lastLoginDate = lastLoginDate
+        self.publishedAt = publishedAt
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.roles = roles
@@ -152,6 +156,7 @@ struct UserDto: Codable {
         fields = try values.decodeIfPresent([FlexiFieldDto].self, forKey: .fields) ?? []
         activityPubProfile = try values.decodeIfPresent(String.self, forKey: .activityPubProfile) ?? ""
         lastLoginDate = try values.decodeIfPresent(Date.self, forKey: .lastLoginDate)
+        publishedAt = try values.decodeIfPresent(Date.self, forKey: .publishedAt)
         createdAt = try values.decodeIfPresent(Date.self, forKey: .createdAt)
         updatedAt = try values.decodeIfPresent(Date.self, forKey: .updatedAt)
         roles = try values.decodeIfPresent([String].self, forKey: .roles)
@@ -185,6 +190,7 @@ struct UserDto: Codable {
         try container.encodeIfPresent(bioHtml, forKey: .bioHtml)
         try container.encodeIfPresent(activityPubProfile, forKey: .activityPubProfile)
         try container.encodeIfPresent(lastLoginDate, forKey: .lastLoginDate)
+        try container.encodeIfPresent(publishedAt, forKey: .publishedAt)
         try container.encodeIfPresent(createdAt, forKey: .createdAt)
         try container.encodeIfPresent(updatedAt, forKey: .updatedAt)
         try container.encodeIfPresent(roles, forKey: .roles)
@@ -222,6 +228,7 @@ extension UserDto {
             activityPubProfile: user.activityPubProfile,
             fields: flexiFields?.map({ FlexiFieldDto(from: $0, baseAddress: baseAddress, isLocalUser: user.isLocal) }),
             roles: roles?.map({ $0.code }),
+            publishedAt: user.publishedAt,
             createdAt: user.createdAt,
             updatedAt: user.updatedAt,
             baseAddress: baseAddress,

--- a/Sources/VernissageServer/Extensions/Application+Seed.swift
+++ b/Sources/VernissageServer/Extensions/Application+Seed.swift
@@ -685,7 +685,8 @@ extension Application {
                             gravatarHash: gravatarHash,
                             privateKey: privateKey,
                             publicKey: publicKey,
-                            isApproved: true)
+                            isApproved: true,
+                            publishedAt: Date())
 
             _ = try await user.save(on: database)
 

--- a/Sources/VernissageServer/Migrations/CreateStatuses.swift
+++ b/Sources/VernissageServer/Migrations/CreateStatuses.swift
@@ -202,4 +202,20 @@ extension Status {
                 .update()
         }
     }
+    
+    struct CreatePublishedAt: AsyncMigration {
+        func prepare(on database: Database) async throws {
+            try await database
+                .schema(Status.schema)
+                .field("publishedAt", .datetime)
+                .update()
+        }
+        
+        func revert(on database: Database) async throws {
+            try await database
+                .schema(Status.schema)
+                .deleteField("publishedAt")
+                .update()
+        }
+    }
 }

--- a/Sources/VernissageServer/Migrations/CreateUsers.swift
+++ b/Sources/VernissageServer/Migrations/CreateUsers.swift
@@ -290,4 +290,20 @@ extension User {
                 .update()
         }
     }
+    
+    struct CreatePublishedAt: AsyncMigration {
+        func prepare(on database: Database) async throws {
+            try await database
+                .schema(User.schema)
+                .field("publishedAt", .datetime)
+                .update()
+        }
+        
+        func revert(on database: Database) async throws {
+            try await database
+                .schema(User.schema)
+                .deleteField("publishedAt")
+                .update()
+        }
+    }
 }

--- a/Sources/VernissageServer/Models/Status.swift
+++ b/Sources/VernissageServer/Models/Status.swift
@@ -87,6 +87,9 @@ final class Status: Model, @unchecked Sendable {
     @Field(key: "activityPubUrl")
     var activityPubUrl: String
     
+    @Timestamp(key: "publishedAt", on: .none)
+    var publishedAt: Date?
+    
     @Timestamp(key: "createdAt", on: .create)
     var createdAt: Date?
 
@@ -109,7 +112,8 @@ final class Status: Model, @unchecked Sendable {
                      commentsDisabled: Bool = false,
                      replyToStatusId: Int64? = nil,
                      mainReplyToStatusId: Int64? = nil,
-                     reblogId: Int64? = nil
+                     reblogId: Int64? = nil,
+                     publishedAt: Date? = nil
     ) {
         self.init()
 
@@ -129,6 +133,7 @@ final class Status: Model, @unchecked Sendable {
         self.contentWarning = contentWarning
         self.commentsDisabled = commentsDisabled
         self.application = application
+        self.publishedAt = publishedAt
 
         self.repliesCount = 0
         self.reblogsCount = 0
@@ -149,7 +154,8 @@ final class Status: Model, @unchecked Sendable {
                      commentsDisabled: Bool = false,
                      replyToStatusId: Int64? = nil,
                      mainReplyToStatusId: Int64? = nil,
-                     reblogId: Int64? = nil
+                     reblogId: Int64? = nil,
+                     publishedAt: Date? = nil
     ) {
         self.init()
 
@@ -169,6 +175,7 @@ final class Status: Model, @unchecked Sendable {
         self.contentWarning = contentWarning
         self.commentsDisabled = commentsDisabled
         self.application = application
+        self.publishedAt = publishedAt
         
         self.repliesCount = 0
         self.reblogsCount = 0

--- a/Sources/VernissageServer/Models/User.swift
+++ b/Sources/VernissageServer/Models/User.swift
@@ -131,6 +131,9 @@ final class User: Model, @unchecked Sendable {
     
     @Field(key: "twoFactorEnabled")
     var twoFactorEnabled: Bool
+
+    @Timestamp(key: "publishedAt", on: .none)
+    var publishedAt: Date?
     
     @Timestamp(key: "createdAt", on: .create)
     var createdAt: Date?
@@ -204,7 +207,8 @@ final class User: Model, @unchecked Sendable {
                      userInbox: String? = nil,
                      userOutbox: String? = nil,
                      lastLoginDate: Date? = nil,
-                     twoFactorEnabled: Bool = false
+                     twoFactorEnabled: Bool = false,
+                     publishedAt: Date? = nil
     ) {
         self.init()
 
@@ -235,6 +239,7 @@ final class User: Model, @unchecked Sendable {
         self.isApproved = isApproved
         self.twoFactorEnabled = twoFactorEnabled
         self.lastLoginDate = lastLoginDate
+        self.publishedAt = publishedAt
         
         self.headerFileName = headerFileName
         self.photosCount = photosCount
@@ -291,7 +296,8 @@ extension User {
             publicKey: publicKey,
             manuallyApprovesFollowers: false,
             reason: registerUserDto.reason,
-            isApproved: isApproved
+            isApproved: isApproved,
+            publishedAt: Date()
         )
     }
     
@@ -326,7 +332,8 @@ extension User {
             privateKey: privateKey,
             publicKey: publicKey,
             manuallyApprovesFollowers: false,
-            isApproved: isApproved
+            isApproved: isApproved,
+            publishedAt: Date()
         )
     }
 

--- a/Sources/VernissageServer/Services/ActivityPubService.swift
+++ b/Sources/VernissageServer/Services/ActivityPubService.swift
@@ -396,7 +396,8 @@ final class ActivityPubService: ActivityPubServiceType {
                                           application: nil,
                                           categoryId: nil,
                                           visibility: .public,
-                                          reblogId: mainStatusFromDatabase.requireID())
+                                          reblogId: mainStatusFromDatabase.requireID(),
+                                          publishedAt: Date())
             
             try await reblogStatus.create(on: context.db)
             try await statusesService.updateReblogsCount(for: mainStatusFromDatabase.requireID(), on: context.db)

--- a/Sources/VernissageServer/Services/StatusesService.swift
+++ b/Sources/VernissageServer/Services/StatusesService.swift
@@ -175,11 +175,12 @@ final class StatusesService: StatusesServiceType {
         
         let userNameMaps = status.mentions.toDictionary()
         let noteHtml = status.note?.html(baseAddress: baseAddress, wrapInParagraph: true, userNameMaps: userNameMaps)
+        let published = status.isLocal ? status.createdAt?.toISO8601String() : (status.publishedAt?.toISO8601String() ?? status.createdAt?.toISO8601String())
         
         let noteDto = NoteDto(id: status.activityPubId,
                               summary: status.contentWarning,
                               inReplyTo: replyToStatus?.activityPubId,
-                              published: status.createdAt?.toISO8601String(),
+                              published: published,
                               url: status.activityPubUrl,
                               attributedTo: status.user.activityPubProfile,
                               to: to,
@@ -422,7 +423,8 @@ final class StatusesService: StatusesServiceType {
                             sensitive: noteDto.sensitive ?? false,
                             contentWarning: noteDto.summary,
                             replyToStatusId: replyToStatus?.id,
-                            mainReplyToStatusId: mainStatus?.id ?? replyToStatus?.id)
+                            mainReplyToStatusId: mainStatus?.id ?? replyToStatus?.id,
+                            publishedAt: noteDto.published?.fromISO8601String())
 
         let attachmentsFromDatabase = savedAttachments
         let replyToStatusFromDatabase = replyToStatus

--- a/Sources/VernissageServer/VernissageServer.docc/ActivityPub.md
+++ b/Sources/VernissageServer/VernissageServer.docc/ActivityPub.md
@@ -1,3 +1,294 @@
 # ActivityPub
 
-*Work in progress...*
+A decentralized social networking protocol based upon the ActivityStreams 2.0 data format and JSON-LD.
+
+## Status federation
+
+Supported activities for statuses (photos):
+
+- `Create` - transformed info status and saved into database.
+- `Delete` - removes a status from database.
+- `Like` - transformed into a favourite on a status.
+- `Announce` - transformed into a boost on a status.
+- `Undo` - undo a previous `Like` or `Annouce`.
+
+### Schema
+
+Vernissage supports only object type `Note`. Notes are transformed into regular statuses (photos). 
+
+> Note: Vernissage can only display notes that include images in the attachment collection.
+
+Notes without any images are not saved to the database. However, if a note is a reply to a previously fetched note (which must include an image), it will be saved to the database.
+
+Used properties:
+
+- `id` - saved as ActivityPub object identifier.
+- `content` - used as a status text.
+- `summary` - used as content warning text.
+- `inReplyTo` - used for threading a status as a reply to another status.
+- `published` - used as status date.
+- `url` - used for status permalinks.
+- `attributedTo` - used to determine the profile which authored the status.
+- `to`/`cc` - used to determine audience and visibility of a status, in combination with mentions.
+- `sensitive` - used to determine whether status media or text should be hidden by default.
+- `tag` - used to mark up mentions, hashtags or emojis (collection of `NoteTagDto`).
+- `attachment` - used to include attached images (collection of `MediaAttachmentDto`).
+
+Properties of `NoteTagDto`:
+
+- `type` - either `Mention`, `Hashtag`, or `Emoji` is currently supported.
+- `name` - the plain-text Webfinger address of a profile `Mention` (@user or @user@domain), or the plain-text `Hashtag` (#tag), or the custom `Emoji` shortcode (:thounking:).
+- `href` - the URL of the actor or tag.
+- `icon` - information about emoji (`NoteTagIconDto` object).
+- `updated` - date when emoji has been updated.
+
+Properties of `NoteTagIconDto`:
+
+- `type` - type of the icon, `Image` is supported only.
+- `mediaType` - mime type of the icon.
+- `url` - url to the file icon.
+
+Properties of `MediaAttachmentDto`:
+
+- `url` - used to fetch the media attachment.
+- `name` - used as media description (ALT text).
+- `mediaType` - used to distinguish if attachment is an image.
+
+Extensions in `MediaAttachmentDto`:
+
+- `blurhash` - used to generate a blurred preview image corresponding to the colors used within the image (see: https://docs.joinmastodon.org/spec/activitypub/#blurhash)
+- `exif` - metadata information about the image (see: https://joinvernissage.org/ns#exif).
+- `location` - extension from https://schema.org (extension: `addressCountry`, type: `Place`).
+- `location.geonameId` - additional extension to location (see: https://joinvernissage.org/ns#geonameId).
+
+### JSON+LD Example
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    {
+      "addressCountry": "schema:addressCountry",
+      "blurhash": "toot:blurhash",
+      "exif": "photos:exif",
+      "geonameId": "photos:geonameId",
+      "photos": "https://joinvernissage.org/ns#",
+      "schema": "https://schema.org",
+      "toot": "http://joinmastodon.org/ns#"
+    }
+  ],
+  "attachment": [
+    {
+      "blurhash": "U1AJ~A_300_300009Fof?b4nIUt7xu%MD%4n",
+      "exif": {
+        "createDate": "2025-02-27T17:38:49.408Z",
+        "exposureTime": "1/200",
+        "fNumber": "f/2.2",
+        "flash": "Flash did not fire, compulsory flash mode",
+        "focalLenIn35mmFilm": "85",
+        "focalLength": "85",
+        "latitude": "51.110501666666664N",
+        "lens": "Zeiss Batis 1.8/85",
+        "longitude": "17.033457778333332E",
+        "make": "SONY",
+        "model": "ILCE-7M4",
+        "photographicSensitivity": "3200"
+      },
+      "height": 2731,
+      "location": {
+        "addressCountry": "PL",
+        "geonameId": "3081368",
+        "latitude": "51,1",
+        "longitude": "17,03333",
+        "name": "Wrocław",
+        "type": "Place"
+      },
+      "mediaType": "image/jpeg",
+      "name": "The image is in black and white, showing a cafe with tables and chairs.",
+      "type": "Image",
+      "url": "https://vernissage.instance/storage/eeb75ee9252a4f1192d8d66be2dcf962.jpg",
+      "width": 4096
+    }
+  ],
+  "attributedTo": "https://vernissage.instance/actors/johndoe",
+  "cc": [
+    "https://vernissage.photos/actors/mczachurski/followers"
+  ],
+  "content": "<p>Waiting...<br /><br /><a href=\"https://vernissage.instance/tags/Photography\" rel=\"tag\" class=\"mention hashtag\">#Photography</a> <a href=\"https://vernissage.instance/tags/Street\" rel=\"tag\" class=\"mention hashtag\">#Street</a> <a href=\"https://vernissage.instance/tags/StreetPhotography\" rel=\"tag\" class=\"mention hashtag\">#StreetPhotography</a> <a href=\"https://vernissage.instance/tags/BlackAndWhite\" rel=\"tag\" class=\"mention hashtag\">#BlackAndWhite</a> <a href=\"https://vernissage.instance/tags/BlackAndWhitePhotography\" rel=\"tag\" class=\"mention hashtag\">#BlackAndWhitePhotography</a></p>",
+  "id": "https://vernissage.instance/actors/johndoe/statuses/7500892058677152209",
+  "published": "2025-05-05T09:32:06.508Z",
+  "sensitive": false,
+  "tag": [
+    {
+      "href": "https://vernissage.instance/tags/BlackAndWhite",
+      "name": "#BlackAndWhite",
+      "type": "Hashtag"
+    },
+    {
+      "href": "https://vernissage.instance/tags/BlackAndWhitePhotography",
+      "name": "#BlackAndWhitePhotography",
+      "type": "Hashtag"
+    },
+    {
+      "href": "https://vernissage.instance/tags/Photography",
+      "name": "#Photography",
+      "type": "Hashtag"
+    },
+    {
+      "href": "https://vernissage.instance/tags/Street",
+      "name": "#Street",
+      "type": "Hashtag"
+    },
+    {
+      "href": "https://vernissage.instance/tags/StreetPhotography",
+      "name": "#StreetPhotography",
+      "type": "Hashtag"
+    }
+  ],
+  "to": [
+    "https://www.w3.org/ns/activitystreams#Public"
+  ],
+  "type": "Note",
+  "url": "https://vernissage.instance/@johndoe/7500892058677152209"
+}
+```
+
+## Profile federation
+
+Supported activities for profiles:
+
+- `Follow` - indicate interest in receiving status updates from a profile.
+- `Accept`/`Reject` - used to approve or deny `Follow` activities. Unlocked accounts will automatically reply with an `Accept`, while locked accounts can manually choose whether to approve or deny a follow request.
+- `Update` - refresh account details.
+- `Delete` - remove an account from the database, as well as all of their statuses.
+- `Undo` - Undo a previous `Follow`.
+
+### Schema
+
+Used properties:
+- `id` - saved as ActivityPub object identifier.
+- `preferredUsername` - used for Webfinger lookup. Must be unique on the domain, and must correspond to a Webfinger acct: URI.
+- `name` - used as profile display name.
+- `summary` - used as a profile bio.
+- `type` - assumed to be `Person`. If type is `Application` or `Service`, it will be interpreted as a bot flag.
+- `url` - used as profile link.
+- `icon` - used as profile avatar.
+- `image` - used as profile header.
+- `manuallyApprovesFollowers` - will be shown as a locked account.
+- `publicKey` - required for signatures (object `PersonPublicKeyDto`).
+- `attachment` - used for profile fields (collection of `PersonAttachmentDto`)
+- `alsoKnownAs` - required for Move activity (collection of strings).
+- `tag` - used to mark up hashtags or emojis (collection of `PersonHashtagDto`).
+- `published` - when the profile was created.
+- `endpoints` - a json object which maps additional (typically server/domain-wide) endpoints which may be useful either for this actor or someone referencing this actor.
+- `inbox` - a reference to an [ActivityStreams] OrderedCollection comprised of all the messages received by the actor.
+- `outbox` - an [ActivityStreams] OrderedCollection comprised of all the messages produced by the actor.
+- `following` - a link to an [ActivityStreams] collection of the actors that this actor is following.
+- `followers` - a link to an [ActivityStreams] collection of the actors that follow this actor.
+
+Properties of `PersonPublicKeyDto`:
+
+- `id` - public key identifier.
+- `owner` - url to public key owner.
+- `publicKeyPem` - public key PEM.
+
+Properties of `PersonAttachmentDto`:
+
+- `type` - only `PropertyValue` extension from https://schema.org is supported.
+- `name` - name of the property.
+- `value` - value of the property.
+
+Properties of `PersonHashtagDtoDto`:
+
+- `name` - the plain-text `Hashtag` (#tag), or the custom `Emoji` shortcode (:thounking:).
+- `href` - the URL of the tag.
+- `icon` - information about emoji (`PersonImageDto` object).
+
+Properties of `PersonImageDto`:
+
+- `type` - type of the icon, `Image` is supported only.
+- `mediaType` - mime type of the icon.
+- `url` - url to the file icon.
+
+### JSON+LD Example
+
+```json
+{
+  "@context": [
+    "https://w3id.org/security/v1",
+    "https://www.w3.org/ns/activitystreams",
+    {
+      "PropertyValue": "schema:PropertyValue",
+      "alsoKnownAs": {
+        "@id": "as:alsoKnownAs",
+        "@type": "@id"
+      },
+      "manuallyApprovesFollowers": "as:manuallyApprovesFollowers",
+      "schema": "https://schema.org",
+      "toot": "http://joinmastodon.org/ns#"
+    }
+  ],
+  "alsoKnownAs": [
+    "https://example.social/users/johndoe"
+  ],
+  "attachment": [
+    {
+      "name": "HOMEPAGE",
+      "type": "PropertyValue",
+      "value": "<a href=\"https://johndoe.dev\" rel=\"me nofollow noopener noreferrer\" class=\"url\" target=\"_blank\"><span class=\"invisible\">https://</span>johndoe.dev</a>"
+    },
+    {
+      "name": "MASTODON",
+      "type": "PropertyValue",
+      "value": "<a href=\"https://example.social/@johndoe\" rel=\"me nofollow noopener noreferrer\" class=\"url\" target=\"_blank\"><span class=\"invisible\">https://</span>example.social/@johndoe</a>"
+    }
+  ],
+  "endpoints": {
+    "sharedInbox": "https://vernissage.photos/shared/inbox"
+  },
+  "followers": "https://vernissage.instance/actors/johndoe/followers",
+  "following": "https://vernissage.instance/actors/johndoe/following",
+  "icon": {
+    "mediaType": "image/jpeg",
+    "type": "Image",
+    "url": "https://vernissage.instance/storage/2043486227r84b5366d52hfddc666149.png"
+  },
+  "id": "https://vernissage.instance/actors/johndoe",
+  "image": {
+    "mediaType": "image/jpeg",
+    "type": "Image",
+    "url": "https://vernissage.instance/storage/564a5c1de4014h2db859jc2be4627cb7.jpg"
+  },
+  "inbox": "https://vernissage.instance/actors/johndoe/inbox",
+  "manuallyApprovesFollowers": false,
+  "name": "John Doe",
+  "outbox": "https://vernissage.instance/actors/johndoe/outbox",
+  "preferredUsername": "johndoe",
+  "publicKey": {
+    "id": "https://vernissage.instance/actors/johndoe#main-key",
+    "owner": "https://vernissage.instance/actors/johndoe",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBBAQEFAAO...NVy8d\n/wIDAQAB\n-----END PUBLIC KEY-----"
+  },
+  "published": "2023-07-01T06:19:36.378Z",
+  "summary": "👨🏻‍💻 Software engineer (favorite technologies: #Swift/#dotNET/#Angular)",
+  "tag": [
+    {
+      "href": "https://vernissage.instance/tags/dotNET",
+      "name": "dotNET",
+      "type": "Hashtag"
+    },
+    {
+      "href": "https://vernissage.instance/tags/Swift",
+      "name": "Swift",
+      "type": "Hashtag"
+    },
+    {
+      "href": "https://vernissage.instance/tags/Angular)",
+      "name": "Angular)",
+      "type": "Hashtag"
+    }
+  ],
+  "type": "Person",
+  "url": "https://vernissage.instance/@johndoe"
+}
+```

--- a/Sources/VernissageServer/VernissageServer.docc/HttpSecurity.md
+++ b/Sources/VernissageServer/VernissageServer.docc/HttpSecurity.md
@@ -1,3 +1,13 @@
 # Http security
 
-*Work in progress...*
+Remote request verification.
+
+Vernissage authenticates every ActivityPub request with exactly the same HTTP Signature scheme that Mastodon describes in its security specification. Each inbound request must include a `Signature` header that:
+
+1. points to the sender’s public key with keyId,
+2. lists the headers that were signed (commonly (request-target) host date digest), and
+3. contains a Base-64-encoded RSA-SHA256 signature of those header values.
+
+When Vernissage receives the request it reconstructs the signed string, fetches the public key referenced by keyId, and verifies the signature. For POST requests it additionally checks the `Digest` header against the body and rejects any message whose `Date` header is older than 12 hours, ensuring both authenticity and integrity of the message.
+
+See the full description in Mastodon’s documentation: [Mastodon Security — HTTP Signatures](https://docs.joinmastodon.org/spec/security/#http).

--- a/Sources/VernissageServer/VernissageServer.docc/WebFinger.md
+++ b/Sources/VernissageServer/VernissageServer.docc/WebFinger.md
@@ -1,3 +1,55 @@
 # WebFinger
 
-*Work in progress...*
+WebFinger translates `@user@domain` into its ActivityPub actor URL.
+
+In Vernissage every account is uniquely identified by its full handle - `@username@domain` - because the same username can exist on many different servers. When you type only `@username` in a post, Vernissage assumes you are referring to someone on your own server and never looks beyond it. To reach a person on another server you must include the domain. Yet even `@alex@dogs.club` is only an alias: before any follow, mention, or reply can be delivered across the network, that alias has to be converted into the account’s canonical ActivityPub actor URL (the JSON document that lists its inbox, outbox, followers, and public key). The conversion happens through `WebFinger`, defined in `RFC 7033`. A Vernissage server sends an HTTPS request to https://dogs.club/.well-known/webfinger?resource=acct:alex@dogs.club and receives a small JSON response whose `"self"` link points to the actor, for example https://dogs.club/users/alex. The server then fetches that actor object and stores it locally so future interactions with `@alex@dogs.club` require no additional lookup.
+
+Because WebFinger is the only standard discovery mechanism Vernissage recognizes, it is effectively mandatory: if a remote domain does not publish `/.well-known/webfinger` or does not respond with the expected `acct:` URI, other Vernissage instances cannot resolve its users, global search for `username@domain` fails, and any mention or follow originating elsewhere is undeliverable. Some non-Vernissage platforms try to bypass this by displaying their full actor URLs, but Vernissage’s internal logic still leans almost entirely on WebFinger and `acct:` URIs. In short, `@user@domain` is the human-friendly label. WebFinger is the DNS-like layer that turns that label into the precise ActivityPub address, and without it federation breaks down.
+
+## Sample WebFinger flow
+
+Suppose we want to lookup the user `@mczachurski` hosted on the `vernissage.photos` website.
+
+Just make a request to that domain’s `/.well-known/webfinger` endpoint, with the resource query parameter set to an `acct:` URI. Request URL: `https://vernissage.photos/.well-known/webfinger?resource=acct:mczachurski@vernissage.photos`:
+
+```json
+{
+  "aliases": [
+    "https://vernissage.photos/@mczachurski",
+    "https://vernissage.photos/actors/mczachurski"
+  ],
+  "links": [
+    {
+      "href": "https://vernissage.photos/actors/mczachurski",
+      "rel": "self",
+      "type": "application/activity+json"
+    },
+    {
+      "href": "https://vernissage.photos/@mczachurski",
+      "rel": "http://webfinger.net/rel/profile-page",
+      "type": "text/html"
+    }
+  ],
+  "subject": "acct:mczachurski@vernissage.photos"
+}
+```
+
+You can parse this JSON response to find a link with your desired type. For ActivityPub id, we are interested in finding `application/activity+json` specifically.
+
+This way, we have translated `@mczachurski@vernissage.photos` to `https://vernissage.photos/actors/mczachurski` and we can now interact over ActivityPub by referring to this URI as id where appropriate. Sample activity:
+
+```json
+{
+"id": "https://social.example/activities/tu6ngi3neu",
+"type": "Create",
+"actor": "https://social.example/profiles/johndoe",
+"object": {
+    "id": "https://social.example/objects/g6khn84u",
+    "type": "Note",
+    "content": "Hello, Marcin!"
+},
+"to": "https://vernissage.photos/actors/mczachurski"
+}
+```
+
+Note in the above example that social.example does not use the same (actor) URI structure as Vernissage. Thus, we cannot guess the actor id given only the username and domain. However, if social.example supports WebFinger, then we can get this id by requesting https://social.example/.well-known/webfinger?resource=acct:johndoe@social.example and parsing the response for a link with the `application/ld+json; profile="https://www.w3.org/ns/activitystreams"` or `application/activity+json` type. This link should also have the link relation `rel="self"`.

--- a/Tests/VernissageServerTests/AcceptanceTests/StatusesController/StatusesCreateActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/StatusesController/StatusesCreateActionTests.swift
@@ -59,6 +59,7 @@ extension ControllersTests {
             #expect(statusRequestDto.replyToStatusId == createdStatusDto.replyToStatusId, "Status replyToStatusId should be correct.")
             #expect(createdStatusDto.user.userName == "martinbore", "User should be returned.")
             #expect(createdStatusDto.category?.name == "Street", "Category should be correct.")
+            #expect(createdStatusDto.publishedAt != nil, "Published at date should be set.")
         }
         
         @Test("Attachments should be returned in correct order")

--- a/Tests/VernissageServerTests/AcceptanceTests/UsersController/UsersReadActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/UsersController/UsersReadActionTests.swift
@@ -41,6 +41,7 @@ extension ControllersTests {
             #expect(userDto.email == user.email, "Property 'email' should be equal.")
             #expect(userDto.name == user.name, "Property 'name' should be equal.")
             #expect(userDto.bio == user.bio, "Property 'bio' should be equal.")
+            #expect(userDto.publishedAt != nil, "Property 'publishedAt' should be returned.")
         }
         
         @Test("User profile should be returned for existing user by full user name")

--- a/Tests/VernissageServerTests/Helpers/Extensions/User.swift
+++ b/Tests/VernissageServerTests/Helpers/Extensions/User.swift
@@ -53,7 +53,8 @@ extension Application {
                         forgotPasswordGuid: forgotPasswordGuid,
                         forgotPasswordDate: forgotPasswordDate,
                         bio: bio,
-                        isApproved: isApproved)
+                        isApproved: isApproved,
+                        publishedAt: Date())
 
         _ = try await user.save(on: self.db)
         return user


### PR DESCRIPTION
Information about original status/person `published` date wasn't save in the database (now we can display in the Web UI original status create date instead of the date when status has been downloaded).