### PR TITLE
Add category to federated Note object (send/save)

### DIFF
--- a/Sources/ActivityPubKit/Entities/ContextDto.swift
+++ b/Sources/ActivityPubKit/Entities/ContextDto.swift
@@ -16,6 +16,7 @@ public final class ContextDto {
     public let geonameId: String?
     public let exif: String?
     public let addressCountry: String?
+    public let category: String?
     
     enum CodingKeys: String, CodingKey {
         case value
@@ -28,8 +29,8 @@ public final class ContextDto {
         case photos
         case geonameId
         case exif
-        case category
         case addressCountry
+        case category = "Category"
     }
     
     public init(value: String) {
@@ -44,6 +45,7 @@ public final class ContextDto {
         self.geonameId = nil
         self.exif = nil
         self.addressCountry = nil
+        self.category = nil
     }
     
     fileprivate init(
@@ -56,7 +58,8 @@ public final class ContextDto {
         photos: String? = nil,
         geonameId: String? = nil,
         exif: String? = nil,
-        addressCountry: String? = nil
+        addressCountry: String? = nil,
+        category: String? = nil
     ) {
         self.value = nil
         self.manuallyApprovesFollowers = manuallyApprovesFollowers
@@ -69,6 +72,7 @@ public final class ContextDto {
         self.geonameId = geonameId
         self.exif = exif
         self.addressCountry = addressCountry
+        self.category = category
     }
     
     public init(from decoder: Decoder) throws {
@@ -85,6 +89,7 @@ public final class ContextDto {
             self.geonameId = nil
             self.exif = nil
             self.addressCountry = nil
+            self.category = nil
         } catch DecodingError.typeMismatch {
             if let objectData = try? container.decode(ContextDataDto.self) {
                 self.value = ""
@@ -98,6 +103,7 @@ public final class ContextDto {
                 self.geonameId = objectData.geonameId
                 self.exif = objectData.exif
                 self.addressCountry = objectData.addressCountry
+                self.category = objectData.category
             } else {
                 self.value = nil
                 self.manuallyApprovesFollowers = nil
@@ -110,6 +116,7 @@ public final class ContextDto {
                 self.geonameId = nil
                 self.exif = nil
                 self.addressCountry = nil
+                self.category = nil
             }
         }
     }
@@ -127,6 +134,7 @@ public final class ContextDto {
             try container.encodeIfPresent(self.geonameId, forKey: .geonameId)
             try container.encodeIfPresent(self.exif, forKey: .exif)
             try container.encodeIfPresent(self.addressCountry, forKey: .addressCountry)
+            try container.encodeIfPresent(self.category, forKey: .category)
         } else {
             var container = encoder.singleValueContainer()
             try container.encode(self.value)
@@ -154,6 +162,7 @@ final fileprivate class ContextDataDto {
     public let geonameId: String?
     public let exif: String?
     public let addressCountry: String?
+    public let category: String?
     
     enum CodingKeys: String, CodingKey {
         case manuallyApprovesFollowers
@@ -166,6 +175,7 @@ final fileprivate class ContextDataDto {
         case geonameId
         case exif
         case addressCountry
+        case category = "Category"
     }
 }
 
@@ -210,7 +220,8 @@ extension ContextDto {
                        photos: "https://joinvernissage.org/ns#",
                        geonameId: "photos:geonameId",
                        exif: "photos:exif",
-                       addressCountry: "schema:addressCountry")
+                       addressCountry: "schema:addressCountry",
+                       category: "photos:Category")
         ])
     }
 }

--- a/Sources/ActivityPubKit/Entities/NoteDto.swift
+++ b/Sources/ActivityPubKit/Entities/NoteDto.swift
@@ -118,6 +118,10 @@ extension ComplexType<NoteTagDto> {
         tags().filter { $0.type == "Mention" && $0.name.isEmpty == false }
     }
     
+    public func categories() -> [NoteTagDto] {
+        tags().filter { $0.type == "Category" && $0.name.isEmpty == false }
+    }
+    
     public func emojis() -> [NoteTagDto] {
         tags().filter { $0.type == "Emoji" && $0.name.isEmpty == false && $0.icon != nil && $0.icon?.url.isEmpty == false }
     }

--- a/Sources/VernissageServer/Models/Category.swift
+++ b/Sources/VernissageServer/Models/Category.swift
@@ -6,6 +6,7 @@
 
 import Fluent
 import Vapor
+import ActivityPubKit
 
 /// Category.
 final class Category: Model, @unchecked Sendable {
@@ -50,3 +51,12 @@ final class Category: Model, @unchecked Sendable {
 
 /// Allows `Category` to be encoded to and decoded from HTTP messages.
 extension Category: Content { }
+
+extension NoteTagDto {
+    init(category: String, baseAddress: String) {
+        self.init(
+            type: "Category",
+            name: category,
+            href: "\(baseAddress)/categories/\(category)")
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/ActivityPubActorsController/ActivityPubActorsStatusActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/ActivityPubActorsController/ActivityPubActorsStatusActionTests.swift
@@ -157,6 +157,34 @@ extension ControllersTests {
 
             #expect(noteDto.tag == ComplexType.multiple([ NoteTagDto(type: "Mention", name: "@gigifoter@localhost:8080", href: "http://localhost:8080/actors/gigifoter") ]), "Property 'tag' is not valid.")
         }
+        
+        @Test("Category should be returned as a tag")
+        func categoryShouldBeReturnedAsTag() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "terryfoter")
+            let category = try await application.getCategory(name: "Street")
+            let (statuses, attachments) = try await application.createStatuses(user: user, notePrefix: "AP note 1", categoryId: category?.stringId(), amount: 1)
+            defer {
+                application.clearFiles(attachments: attachments)
+            }
+            
+            // Act.
+            let noteDto = try await application.getResponse(
+                to: "/actors/trondfoter/statuses/\(statuses.first!.requireID())",
+                version: .none,
+                decodeTo: NoteDto.self
+            )
+            
+            // Assert.
+            #expect(noteDto.id == "http://localhost:8080/actors/terryfoter/statuses/\(statuses.first?.stringId() ?? "")", "Property 'id' is not valid.")
+            #expect(noteDto.attachment?.count == 1, "Property 'attachment' is not valid.")
+            #expect(noteDto.attributedTo == "http://localhost:8080/actors/terryfoter", "Property 'attributedTo' is not valid.")
+            #expect(noteDto.url == "http://localhost:8080/@terryfoter/\(statuses.first?.stringId() ?? "")", "Property 'url' is not valid.")
+            #expect(noteDto.tag == ComplexType.multiple([
+                NoteTagDto(type: "Category", name: "Street", href: "http://localhost:8080/categories/Street")
+            ]), "Property 'tag' should contain category.")
+        }
     }
 }
 

--- a/Tests/VernissageServerTests/ServicesTests/StatusesServiceTests.swift
+++ b/Tests/VernissageServerTests/ServicesTests/StatusesServiceTests.swift
@@ -26,7 +26,7 @@ struct StatusesServiceTests {
         let noteTagDtos = [NoteTagDto(type: "hashtag", name: "Street", href: ""), NoteTagDto(type: "hashtag", name: "Street", href: "")]
         
         // Act.
-        let category = try await statusesService.getCategory(basedOn: noteTagDtos, on: application.db)
+        let category = try await statusesService.getCategory(basedOn: noteTagDtos, and: [], on: application.db)
         
         // Assert.
         #expect(category?.name == "Street", "Street category should be returned.")
@@ -41,7 +41,7 @@ struct StatusesServiceTests {
         let noteTagDtos = [NoteTagDto(type: "hashtag", name: "nature", href: ""), NoteTagDto(type: "hashtag", name: "pet", href: "")]
         
         // Act.
-        let category = try await statusesService.getCategory(basedOn: noteTagDtos, on: application.db)
+        let category = try await statusesService.getCategory(basedOn: noteTagDtos, and: [], on: application.db)
         
         // Assert.
         #expect(category?.name == "Animals", "Animals category should be returned.")


### PR DESCRIPTION
Now category is exposed as a tag:

```json
{
  "@context": [
    "https://www.w3.org/ns/activitystreams",
    {
      "Category": "photos:Category",
      "photos": "https://joinvernissage.org/ns#"
    }
  ],
  "attributedTo": "https://joinvernissage.org/actors/johndoe",
  "cc": [
    "https://joinvernissage.org/actors/johndoe/followers"
  ],
  "content": "Note text",
  "id": "https://joinvernissage.org/actors/johndoe/statuses/7359535244628142081",
  "published": "2024-04-19T11:15:42.779Z",
  "tag": [
    {
      "href": "https://joinvernissage.org/categories/Abstract",
      "name": "Abstract",
      "type": "Category"
    }
  ],
  "to": [
    "https://www.w3.org/ns/activitystreams#Public"
  ],
  "type": "Note",
  "url": "https://joinvernissage.org/@johndoe/7359535244628142081"
}
```