### PR TITLE
#393 Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you’ve identified a **security vulnerability** in Vernissage Server (for example, a flaw that could allow unauthorized access to data, bypass security checks, or perform actions that should not be possible), you can either:
+
+- open a [GitHub security issue on the Vernissage Server project](https://github.com/VernissageApp/VernissageServer/security/advisories/new)
+- reach us at <info@vernissage.photos>
+
+A **security issue** is a problem in the software that could be exploited to harm users, compromise their privacy, or affect the integrity of the system.
+
+You should _not_ report such issues on public GitHub issues or in other public spaces. This gives us time to investigate and release a fix before the details become widely known, reducing the risk to Vernissage’s users.
+
+## Scope
+
+A "vulnerability in Vernissage" refers to a flaw in the code provided through our official GitHub source code repository. Issues that arise from a specific deployment or configuration (for example, server misconfiguration or insecure hosting environment) are not considered vulnerabilities in Vernissage itself and should be reported directly to the administrator or owner of that particular installation, rather than to us.
+
+## Supported Versions
+
+Below is the list of Vernissage Server (API) versions that receive security patches.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x.x   | :white_check_mark: |


### PR DESCRIPTION
This commit introduces a SECURITY.md file outlining the process for responsibly reporting security vulnerabilities in Vernissage.