### PR TITLE
Fix request example in AttachmentsController.update

### DIFF
--- a/Sources/VernissageServer/Controllers/AttachmentsController.swift
+++ b/Sources/VernissageServer/Controllers/AttachmentsController.swift
@@ -477,6 +477,8 @@ struct AttachmentsController {
     /// ```json
     /// {
     ///     "id": "7333524055101298689",
+    ///     "url": "",
+    ///     "previewUrl": "",
     ///     "description": "This is the cat.",
     ///     "blurhash": "U5C?r]~q00xu9F-;WBIU009F~q%M-;ayj[xu",
     ///     "make": "SONY",
@@ -489,8 +491,8 @@ struct AttachmentsController {
     ///     "photographicSensitivity": "100",
     ///     "locationId": "7257110934739898369",
     ///     "licenseId": "7310942225159020545",
-    ///     "latitude: "50,67211",
-    ///     "longitude: "17,92533",
+    ///     "latitude": "50,67211",
+    ///     "longitude": "17,92533",
     /// }
     /// ```
     ///


### PR DESCRIPTION
The example as written does not work, because:

(a) it is invalid JSON
(b) the `url` and `previewUrl` fields are required and apparently also
    have to be empty strings.

I may be wrong about (b) in particular, but only with `url` and `previewUrl` set to the empty string [like the web app does][1] I managed to get a 200 response from the endpoint (previously, I always got `incorrectRequestFormat`).

   [1]: https://github.com/VernissageApp/VernissageWeb/blob/develop/src/app/models/temporary-attachment.ts#L3-L4