### PR TITLE
Change maximum number of trending accounts/hashtags/statuses

### DIFF
--- a/Sources/VernissageServer/Services/TrendingService.swift
+++ b/Sources/VernissageServer/Services/TrendingService.swift
@@ -335,7 +335,7 @@ final class TrendingService: TrendingServiceType {
                 AND \(ident: "s").\(ident: "replyToStatusId") IS NULL
             GROUP BY \(ident: "sf").\(ident: "statusId"), \(ident: "s").\(ident: "createdAt")
             ORDER BY COUNT(\(ident: "sf").\(ident: "statusId")), \(ident: "s").\(ident: "createdAt") DESC
-            LIMIT 10000
+            LIMIT 1000
         """).all(decoding: TrendingAmount.self)
         
         return trendingAmounts
@@ -356,7 +356,7 @@ final class TrendingService: TrendingServiceType {
                 AND \(ident: "s").\(ident: "replyToStatusId") IS NULL
             GROUP BY \(ident: "s").\(ident: "userId")
             ORDER BY COUNT(\(ident: "s").\(ident: "userId")) DESC
-            LIMIT 10000
+            LIMIT 1000
         """).all(decoding: TrendingAmount.self)
         
         return trendingAmounts
@@ -378,7 +378,7 @@ final class TrendingService: TrendingServiceType {
                 AND \(ident: "s").\(ident: "replyToStatusId") IS NULL
             GROUP BY \(ident: "st").\(ident: "hashtagNormalized")
             ORDER BY COUNT(\(ident: "st").\(ident: "hashtagNormalized")) DESC
-            LIMIT 10000
+            LIMIT 1000
         """).all(decoding: TrendingHashtagAmount.self)
         
         return trendingHashtag


### PR DESCRIPTION
To mitigate potential database issues, we must restrict the number of rows inserted during trending recalculations. Previously, we had inserted 10,000 rows for each hashtag, account, or status, which resulted in a `PSQLError(code: tooManyParameters)`. However, we can now calculate 1,000 rows, which remains a substantial number.