### PR TITLE
Fix clearing attachments with histories

### DIFF
--- a/Sources/VernissageServer/Constants.swift
+++ b/Sources/VernissageServer/Constants.swift
@@ -9,7 +9,7 @@ import Vapor
 /// Basic constants used in the system.
 public final class Constants {
     public static let name = "Vernissage"
-    public static let version = "1.26.0-buildx"
+    public static let version = "1.27.0-buildx"
     public static let applicationName = "\(Constants.name) \(Constants.version)"
     public static let userAgent = "(\(Constants.name)/\(Constants.version))"
     public static let requestMetadata = "Request body"

--- a/Sources/VernissageServer/Services/ClearAttachmentsService.swift
+++ b/Sources/VernissageServer/Services/ClearAttachmentsService.swift
@@ -181,9 +181,14 @@ final class ClearAttachmentsService: ClearAttachmentsServiceType {
                 let attchmentOrginalFile = try await Attachment.query(on: context.db)
                     .filter(\.$originalFile.$id == attachmentHistory.$originalFile.id)
                     .first()
+
+                let otherAttchmentHistoryOrginalFile = try await AttachmentHistory.query(on: context.db)
+                    .filter(\.$originalFile.$id == attachmentHistory.$originalFile.id)
+                    .filter(\.$id != attachmentHistory.requireID())
+                    .first()
                 
                 // Remove files from external storage provider.
-                if attchmentOrginalFile == nil {
+                if attchmentOrginalFile == nil && otherAttchmentHistoryOrginalFile == nil {
                     context.logger.info("[ClearAttachmentsJob] Delete attachment history orginal file from storage: \(attachmentHistory.originalFile.fileName).")
                     try await storageService.delete(fileName: attachmentHistory.originalFile.fileName, on: context)
                 }
@@ -192,7 +197,12 @@ final class ClearAttachmentsService: ClearAttachmentsServiceType {
                     .filter(\.$smallFile.$id == attachmentHistory.$smallFile.id)
                     .first()
                 
-                if attchmentSmallFile == nil {
+                let otherAttchmentHistorySmallFile = try await AttachmentHistory.query(on: context.db)
+                    .filter(\.$smallFile.$id == attachmentHistory.$smallFile.id)
+                    .filter(\.$id != attachmentHistory.requireID())
+                    .first()
+                
+                if attchmentSmallFile == nil && otherAttchmentHistorySmallFile == nil {
                     context.logger.info("[ClearAttachmentsJob] Delete attachment history small file from storage: \(attachmentHistory.smallFile.fileName).")
                     try await storageService.delete(fileName: attachmentHistory.smallFile.fileName, on: context)
                 }
@@ -201,7 +211,12 @@ final class ClearAttachmentsService: ClearAttachmentsServiceType {
                     .filter(\.$originalHdrFile.$id == attachmentHistory.$originalHdrFile.id)
                     .first()
                 
-                if let orginalHdrFileName = attachmentHistory.originalHdrFile?.fileName, attchmentOriginalHdrFile == nil {
+                let otherAttchmentHistoryOriginalHdrFile = try await AttachmentHistory.query(on: context.db)
+                    .filter(\.$originalHdrFile.$id == attachmentHistory.$originalHdrFile.id)
+                    .filter(\.$id != attachmentHistory.requireID())
+                    .first()
+                
+                if let orginalHdrFileName = attachmentHistory.originalHdrFile?.fileName, attchmentOriginalHdrFile == nil && otherAttchmentHistoryOriginalHdrFile == nil {
                     context.logger.info("[ClearAttachmentsJob] Delete attachment history orginal HDR file from storage: \(orginalHdrFileName).")
                     try await storageService.delete(fileName: orginalHdrFileName, on: context)
                 }
@@ -214,15 +229,15 @@ final class ClearAttachmentsService: ClearAttachmentsServiceType {
                     try await attachmentHistory.exif?.delete(on: transaction)
                     try await attachmentHistory.delete(on: transaction)
 
-                    if attchmentOrginalFile == nil {
+                    if attchmentOrginalFile == nil && otherAttchmentHistoryOrginalFile == nil {
                         try await attachmentHistory.originalFile.delete(on: transaction)
                     }
                     
-                    if attchmentSmallFile == nil {
+                    if attchmentSmallFile == nil && otherAttchmentHistorySmallFile == nil {
                         try await attachmentHistory.smallFile.delete(on: transaction)
                     }
                     
-                    if attchmentOriginalHdrFile == nil {
+                    if attchmentOriginalHdrFile == nil && otherAttchmentHistoryOriginalHdrFile == nil {
                         try await attachmentHistory.originalHdrFile?.delete(on: transaction)
                     }
                 }


### PR DESCRIPTION
During the cleanup of attachments to statuses, the history (older than one day) was removed first, and then the attachment itself (older than one day). After such a process, a few history entries that were not yet older than one day could remain. This caused a situation where, during the next cleanup (when those entries were already older than one day) there was an attempt to remove the first attachment from the history. However, another one still existed and blocked the removal of the previous one, because both referred to the same file ID.

That situation caused an error:

```
Optional(PSQLError(code: server, serverInfo: [sqlState: 23503, detail: Key (id)=(7521735998821110392) is still referenced from table "AttachmentHistories"., file: ri_triggers.c, line: 2621, message: update or delete on table "FileInfos" violates foreign key constraint "AttachmentHistories_originalFileId_fkey" on table "AttachmentHistories", routine: ri_ReportViolation, localizedSeverity: ERROR, severity: ERROR, constraintName: AttachmentHistories_originalFileId_fkey, schemaName: public, tableName: AttachmentHistories], triggeredFromRequestInFile: PostgresKit/PostgresDatabase+SQL.swift, line: 62, query: PostgresQuery(sql: DELETE FROM "FileInfos" WHERE "FileInfos"."id" = $1, binds: [(****; BIGINT; format: binary)])))
```