### PR TITLE
Include posts/profile in search engines feature on account

### DIFF
--- a/Sources/VernissageServer/Application+Configure.swift
+++ b/Sources/VernissageServer/Application+Configure.swift
@@ -426,6 +426,7 @@ extension Application {
         self.migrations.add(UserStatus.CreateForeignIndexes())
         
         self.migrations.add(User.AddIsSupporterField())
+        self.migrations.add(User.AddIncludeInSearchEngines())
         
         try await self.autoMigrate()
     }

--- a/Sources/VernissageServer/DataTransferObjects/UserDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/UserDto.swift
@@ -36,6 +36,8 @@ struct UserDto: Codable {
     var roles: [String]?
     var twoFactorEnabled: Bool?
     var manuallyApprovesFollowers: Bool?
+    var includePublicPostsInSearchEngines: Bool?
+    var includeProfilePageInSearchEngines: Bool?
     var featured: Bool?
     var isSupporter: Bool?
     var isSupporterFlagEnabled: Bool?
@@ -70,6 +72,8 @@ struct UserDto: Codable {
         case roles
         case twoFactorEnabled
         case manuallyApprovesFollowers
+        case includePublicPostsInSearchEngines
+        case includeProfilePageInSearchEngines
         case featured
         case isSupporter
         case isSupporterFlagEnabled
@@ -93,6 +97,8 @@ struct UserDto: Codable {
          followingCount: Int,
          twoFactorEnabled: Bool? = nil,
          manuallyApprovesFollowers: Bool? = nil,
+         includePublicPostsInSearchEngines: Bool? = nil,
+         includeProfilePageInSearchEngines: Bool? = nil,
          activityPubProfile: String = "",
          fields: [FlexiFieldDto]? = nil,
          roles: [String]? = nil,
@@ -130,6 +136,8 @@ struct UserDto: Codable {
         self.roles = roles
         
         self.manuallyApprovesFollowers = manuallyApprovesFollowers
+        self.includePublicPostsInSearchEngines = includePublicPostsInSearchEngines
+        self.includeProfilePageInSearchEngines = includeProfilePageInSearchEngines
         self.twoFactorEnabled = twoFactorEnabled
         self.email = nil
         self.emailWasConfirmed = nil
@@ -170,6 +178,8 @@ struct UserDto: Codable {
         roles = try values.decodeIfPresent([String].self, forKey: .roles)
         twoFactorEnabled = try values.decodeIfPresent(Bool.self, forKey: .twoFactorEnabled) ?? false
         manuallyApprovesFollowers = try values.decodeIfPresent(Bool.self, forKey: .manuallyApprovesFollowers) ?? false
+        includePublicPostsInSearchEngines = try values.decodeIfPresent(Bool.self, forKey: .includePublicPostsInSearchEngines) ?? false
+        includeProfilePageInSearchEngines = try values.decodeIfPresent(Bool.self, forKey: .includeProfilePageInSearchEngines) ?? false
         featured = try values.decodeIfPresent(Bool.self, forKey: .featured) ?? false
         isSupporter = try values.decodeIfPresent(Bool.self, forKey: .isSupporter) ?? false
         isSupporterFlagEnabled = try values.decodeIfPresent(Bool.self, forKey: .isSupporterFlagEnabled) ?? false
@@ -206,6 +216,8 @@ struct UserDto: Codable {
         try container.encodeIfPresent(roles, forKey: .roles)
         try container.encodeIfPresent(twoFactorEnabled, forKey: .twoFactorEnabled)
         try container.encodeIfPresent(manuallyApprovesFollowers, forKey: .manuallyApprovesFollowers)
+        try container.encodeIfPresent(includePublicPostsInSearchEngines, forKey: .includePublicPostsInSearchEngines)
+        try container.encodeIfPresent(includeProfilePageInSearchEngines, forKey: .includeProfilePageInSearchEngines)
         try container.encodeIfPresent(featured, forKey: .featured)
         try container.encodeIfPresent(isSupporter, forKey: .isSupporter)
         try container.encodeIfPresent(isSupporterFlagEnabled, forKey: .isSupporterFlagEnabled)
@@ -237,6 +249,8 @@ extension UserDto {
             statusesCount: user.statusesCount,
             followersCount: user.followersCount,
             followingCount: user.followingCount,
+            includePublicPostsInSearchEngines: user.includePublicPostsInSearchEngines,
+            includeProfilePageInSearchEngines: user.includeProfilePageInSearchEngines,
             activityPubProfile: user.activityPubProfile,
             fields: flexiFields?.map({ FlexiFieldDto(from: $0, baseAddress: baseAddress, isLocalUser: user.isLocal) }),
             roles: roles?.map({ $0.code }),

--- a/Sources/VernissageServer/Migrations/CreateUsers.swift
+++ b/Sources/VernissageServer/Migrations/CreateUsers.swift
@@ -332,4 +332,30 @@ extension User {
                 .update()
         }
     }
+    
+    struct AddIncludeInSearchEngines: AsyncMigration {
+        func prepare(on database: Database) async throws {
+            try await database
+                .schema(User.schema)
+                .field("includePublicPostsInSearchEngines", .bool, .required, .sql(.default(false)))
+                .update()
+            
+            try await database
+                .schema(User.schema)
+                .field("includeProfilePageInSearchEngines", .bool, .required, .sql(.default(false)))
+                .update()
+        }
+        
+        func revert(on database: Database) async throws {
+            try await database
+                .schema(User.schema)
+                .deleteField("includePublicPostsInSearchEngines")
+                .update()
+            
+            try await database
+                .schema(User.schema)
+                .deleteField("includeProfilePageInSearchEngines")
+                .update()
+        }
+    }
 }

--- a/Sources/VernissageServer/Models/User.swift
+++ b/Sources/VernissageServer/Models/User.swift
@@ -93,6 +93,12 @@ final class User: Model, @unchecked Sendable {
     @Field(key: "manuallyApprovesFollowers")
     var manuallyApprovesFollowers: Bool
     
+    @Field(key: "includePublicPostsInSearchEngines")
+    var includePublicPostsInSearchEngines: Bool
+    
+    @Field(key: "includeProfilePageInSearchEngines")
+    var includeProfilePageInSearchEngines: Bool
+    
     @Field(key: "reason")
     var reason: String?
     
@@ -198,6 +204,8 @@ final class User: Model, @unchecked Sendable {
                      privateKey: String? = nil,
                      publicKey: String? = nil,
                      manuallyApprovesFollowers: Bool = false,
+                     includePublicPostsInSearchEngines: Bool = false,
+                     includeProfilePageInSearchEngines: Bool = false,
                      forgotPasswordGuid: String? = nil,
                      forgotPasswordDate: Date? = nil,
                      bio: String? = nil,
@@ -239,6 +247,8 @@ final class User: Model, @unchecked Sendable {
         self.privateKey = privateKey
         self.publicKey = publicKey
         self.manuallyApprovesFollowers = manuallyApprovesFollowers
+        self.includePublicPostsInSearchEngines = includeProfilePageInSearchEngines
+        self.includeProfilePageInSearchEngines = includeProfilePageInSearchEngines
         self.forgotPasswordGuid = forgotPasswordGuid
         self.forgotPasswordDate = forgotPasswordDate
         self.bio = bio

--- a/Sources/VernissageServer/Services/UsersService.swift
+++ b/Sources/VernissageServer/Services/UsersService.swift
@@ -712,6 +712,8 @@ final class UsersService: UsersServiceType {
         user.name = userDto.name
         user.bio = userDto.bio
         user.manuallyApprovesFollowers = userDto.manuallyApprovesFollowers ?? false
+        user.includePublicPostsInSearchEngines = userDto.includePublicPostsInSearchEngines ?? false
+        user.includeProfilePageInSearchEngines = userDto.includeProfilePageInSearchEngines ?? false
         
         if let locale = userDto.locale {
             user.locale = locale

--- a/Tests/VernissageServerTests/AcceptanceTests/UsersController/UsersUpdateActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/UsersController/UsersUpdateActionTests.swift
@@ -35,6 +35,8 @@ extension ControllersTests {
                                   followersCount: 0,
                                   followingCount: 0,
                                   manuallyApprovesFollowers: true,
+                                  includePublicPostsInSearchEngines: true,
+                                  includeProfilePageInSearchEngines: true,
                                   baseAddress: "http://localhost:8080")
             
             // Act.
@@ -54,6 +56,8 @@ extension ControllersTests {
             #expect(updatedUserDto.name == userDto.name, "Property 'name' should be changed.")
             #expect(updatedUserDto.bio == userDto.bio, "Property 'bio' should be changed.")
             #expect(updatedUserDto.manuallyApprovesFollowers == true, "Property 'manuallyApprovesFollowers' should be changed.")
+            #expect(updatedUserDto.includePublicPostsInSearchEngines == true, "Property 'includePublicPostsInSearchEngines' should be changed.")
+            #expect(updatedUserDto.includeProfilePageInSearchEngines == true, "Property 'includeProfilePageInSearchEngines' should be changed.")
         }
         
         @Test


### PR DESCRIPTION
Thanks to this feature users can enable indexing their profile or/and statuses by external search engines. By default all profiles/statuses are not indexed.