### PR TITLE
Fix parsing of person attachments with Link type

### DIFF
--- a/Sources/ActivityPubKit/Entities/PersonAttachmentDto.swift
+++ b/Sources/ActivityPubKit/Entities/PersonAttachmentDto.swift
@@ -5,15 +5,16 @@
 //
 
 public struct PersonAttachmentDto {
-    public let type = "PropertyValue"
+    public let type: String
     public let name: String
-    public let value: String
-    
+    public let value: String?
+
     public init(name: String, value: String) {
+        self.type = "PropertyValue"
         self.name = name
         self.value = value
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case type
         case name

--- a/Sources/ActivityPubKit/Entities/PersonDto.swift
+++ b/Sources/ActivityPubKit/Entities/PersonDto.swift
@@ -138,6 +138,10 @@ public extension PersonDto {
 
         return clearName.trimmingCharacters(in: .whitespacesAndNewlines)
     }
+    
+    func flexiFields() -> [PersonAttachmentDto]? {
+        return self.attachment?.filter { $0.type == "PropertyValue" }
+    }
 }
 
 extension PersonDto: Codable {

--- a/Sources/VernissageServer/Services/UsersService.swift
+++ b/Sources/VernissageServer/Services/UsersService.swift
@@ -765,14 +765,14 @@ final class UsersService: UsersServiceType {
         // Save user data.
         try await user.update(on: context.db)
         
-        // Update flexi-fields
-        if let flexiFieldsDto = person.attachment?.map({ FlexiFieldDto(key: $0.name, value: $0.value, baseAddress: "") }) {
+        // Update flexi-fields (only include PropertyValue attachments).
+        if let flexiFieldsDto = person.attachment?.compactMap({ $0.type == "PropertyValue" ? FlexiFieldDto(key: $0.name, value: $0.value, baseAddress: "") : nil }) {
             try await self.update(flexiFields: flexiFieldsDto, for: user, on: context)
         }
-        
+
         return user
     }
-    
+
     func create(basedOn person: PersonDto, withAvatarFileName avatarFileName: String?, withHeaderFileName headerFileName: String?, on context: ExecutionContext) async throws -> User {
         
         let urls = person.url.values()
@@ -811,8 +811,8 @@ final class UsersService: UsersServiceType {
         // Save user to database.
         try await user.save(on: context.db)
         
-        // Create flexi-fields
-        if let flexiFieldsDto = person.attachment?.map({ FlexiFieldDto(key: $0.name, value: $0.value, baseAddress: "") }) {
+        // Create flexi-fields (only include PropertyValue attachments).
+        if let flexiFieldsDto = person.attachment?.compactMap({ $0.type == "PropertyValue" ? FlexiFieldDto(key: $0.name, value: $0.value, baseAddress: "") : nil }) {
             try await self.update(flexiFields: flexiFieldsDto, for: user, on: context)
         }
         

--- a/Sources/VernissageServer/Services/UsersService.swift
+++ b/Sources/VernissageServer/Services/UsersService.swift
@@ -362,7 +362,7 @@ final class UsersService: UsersServiceType {
     func getPersonDto(for user: User, on context: ExecutionContext) async throws -> PersonDto {
         let applicationSettings = context.application.settings.cached
         let baseAddress = applicationSettings?.baseAddress ?? ""
-        let attachments = try await user.$flexiFields.get(on: context.db)
+        let flexiFields = try await user.$flexiFields.get(on: context.db)
         let hashtags = try await user.$hashtags.get(on: context.db)
         let aliases = try await user.$aliases.get(on: context.db)
         let published: String? = user.isLocal ? user.createdAt?.toISO8601String() : user.publishedAt?.toISO8601String()
@@ -385,7 +385,7 @@ final class UsersService: UsersServiceType {
                                   icon: self.getPersonImage(for: user.avatarFileName, on: context),
                                   image: self.getPersonImage(for: user.headerFileName, on: context),
                                   endpoints: PersonEndpointsDto(sharedInbox: "\(baseAddress)/shared/inbox"),
-                                  attachment: attachments.map({ PersonAttachmentDto(name: $0.key ?? "",
+                                  attachment: flexiFields.map({ PersonAttachmentDto(name: $0.key ?? "",
                                                                                     value: $0.htmlValue(baseAddress: baseAddress)) }),
                                   tag: hashtags.map({ PersonHashtagDto(type: .hashtag, name: $0.hashtag, href: "\(baseAddress)/tags/\($0.hashtag)") })
         )
@@ -766,7 +766,7 @@ final class UsersService: UsersServiceType {
         try await user.update(on: context.db)
         
         // Update flexi-fields (only include PropertyValue attachments).
-        if let flexiFieldsDto = person.attachment?.compactMap({ $0.type == "PropertyValue" ? FlexiFieldDto(key: $0.name, value: $0.value, baseAddress: "") : nil }) {
+        if let flexiFieldsDto = person.flexiFields()?.map({ FlexiFieldDto(key: $0.name, value: $0.value, baseAddress: "") }) {
             try await self.update(flexiFields: flexiFieldsDto, for: user, on: context)
         }
 
@@ -812,7 +812,7 @@ final class UsersService: UsersServiceType {
         try await user.save(on: context.db)
         
         // Create flexi-fields (only include PropertyValue attachments).
-        if let flexiFieldsDto = person.attachment?.compactMap({ $0.type == "PropertyValue" ? FlexiFieldDto(key: $0.name, value: $0.value, baseAddress: "") : nil }) {
+        if let flexiFieldsDto = person.flexiFields()?.map({ FlexiFieldDto(key: $0.name, value: $0.value, baseAddress: "") }) {
             try await self.update(flexiFields: flexiFieldsDto, for: user, on: context)
         }
         

--- a/Tests/ActivityPubKitTests/ActivityDtoDeserialization.swift
+++ b/Tests/ActivityPubKitTests/ActivityDtoDeserialization.swift
@@ -675,6 +675,54 @@ struct ActivityDtoDeserialization {
 }
 """
     
+    private let personCase10 =
+"""
+{
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1"
+    ],
+    "id": "https://example.com/author/johndoe/",
+    "type": "Person",
+    "preferredUsername": "johndoe",
+    "name": "John Doe",
+    "inbox": "https://example.com/wp-json/activitypub/1.0/users/1/inbox",
+    "outbox": "https://example.com/wp-json/activitypub/1.0/users/1/outbox",
+    "url": "https://example.com/author/johndoe/",
+    "endpoints": {
+        "sharedInbox": "https://example.com/wp-json/activitypub/1.0/inbox"
+    },
+    "publicKey": {
+        "id": "https://example.com/author/johndoe/#main-key",
+        "owner": "https://example.com/author/johndoe/",
+        "publicKeyPem": "-----BEGIN PUBLIC KEY-----AAAAA-----END PUBLIC KEY-----"
+    },
+    "attachment": [
+        {
+            "type": "PropertyValue",
+            "name": "Blog",
+            "value": "<a href=\\"https://example.com/\\">example.com</a>"
+        },
+        {
+            "type": "Link",
+            "name": "Blog",
+            "href": "https://example.com/",
+            "rel": ["me", "noopener"]
+        },
+        {
+            "type": "PropertyValue",
+            "name": "GitHub",
+            "value": "<a href=\\"https://github.com/johndoe\\">github.com/johndoe</a>"
+        },
+        {
+            "type": "Link",
+            "name": "GitHub",
+            "href": "https://github.com/johndoe"
+        }
+    ]
+}
+"""
+
     let statusCase07 = """
 {
   "@context": [
@@ -885,6 +933,32 @@ struct ActivityDtoDeserialization {
 
         // Assert.
         #expect(personDto.manuallyApprovesFollowers == false)
+    }
+
+    @Test
+    func `JSON with mixed PropertyValue and Link attachments should deserialize`() throws {
+
+        // Act.
+        let personDto = try self.decoder.decode(PersonDto.self, from: personCase10.data(using: .utf8)!)
+
+        // Assert.
+        #expect(personDto.attachment?.count == 4)
+
+        #expect(personDto.attachment?[0].type == "PropertyValue")
+        #expect(personDto.attachment?[0].name == "Blog")
+        #expect(personDto.attachment?[0].value != nil)
+
+        #expect(personDto.attachment?[1].type == "Link")
+        #expect(personDto.attachment?[1].name == "Blog")
+        #expect(personDto.attachment?[1].value == nil)
+
+        #expect(personDto.attachment?[2].type == "PropertyValue")
+        #expect(personDto.attachment?[2].name == "GitHub")
+        #expect(personDto.attachment?[2].value != nil)
+
+        #expect(personDto.attachment?[3].type == "Link")
+        #expect(personDto.attachment?[3].name == "GitHub")
+        #expect(personDto.attachment?[3].value == nil)
     }
     
     @Test

--- a/Tests/ActivityPubKitTests/ActivityDtoDeserialization.swift
+++ b/Tests/ActivityPubKitTests/ActivityDtoDeserialization.swift
@@ -962,6 +962,25 @@ struct ActivityDtoDeserialization {
     }
     
     @Test
+    func `Only flexi fields should be returned from deserialized object by flexiField function`() throws {
+
+        // Act.
+        let personDto = try self.decoder.decode(PersonDto.self, from: personCase10.data(using: .utf8)!)
+
+        // Assert.
+        let flexiFields = personDto.flexiFields()
+        #expect(flexiFields?.count == 2)
+        
+        #expect(flexiFields?[0].type == "PropertyValue")
+        #expect(flexiFields?[0].name == "Blog")
+        #expect(flexiFields?[0].value != nil)
+
+        #expect(flexiFields?[1].type == "PropertyValue")
+        #expect(flexiFields?[1].name == "GitHub")
+        #expect(flexiFields?[1].value != nil)
+    }
+    
+    @Test
     func `JSON with create status1 should deserialize`() throws {
         // Act.
         let activityDto = try self.decoder.decode(ActivityDto.self, from: statusCase01.data(using: .utf8)!)


### PR DESCRIPTION
## Summary

- Fix following WordPress blogs by handling Link type attachments

WordPress ActivityPub plugin sends both `PropertyValue` and `Link` types in the attachment array:

```json
"attachment": [
    {
      "type": "PropertyValue",
      "name": "Blog",
      "value": "<a href=\"https://example.com/\">example.com</a>"
    },
    {
      "type": "Link",
      "name": "Blog",
      "href": "https://example.com/"
    }
]
```

The `Link` type doesn't have a `value` field, causing the entire profile parsing to fail. This PR:
- Makes `value` optional in `PersonAttachmentDto`
- Filters to only include `PropertyValue` attachments when creating flexi-fields

## Test plan

- [ ] Follow a WordPress blog with ActivityPub enabled
- [ ] Verify profile is fetched and displayed correctly
- [ ] Run `swift test --filter "JSON with mixed PropertyValue and Link attachments should deserialize"`