### PR TITLE
Add support for Article type objects

### DIFF
--- a/Sources/ActivityPubKit/Entities/ObjectDto.swift
+++ b/Sources/ActivityPubKit/Entities/ObjectDto.swift
@@ -45,7 +45,7 @@ public final class ObjectDto: CommonObjectDto {
             self.name = objectData.name
             
             switch self.type {
-            case .note:
+            case .note, .article:
                 self.object = try? NoteDto(from: decoder)
             case .follow:
                 self.object = try? FollowDto(from: decoder)

--- a/Sources/VernissageServer/Services/ActivityPubService.swift
+++ b/Sources/VernissageServer/Services/ActivityPubService.swift
@@ -280,11 +280,11 @@ final class ActivityPubService: ActivityPubServiceType {
         let statusesService = context.services.statusesService
         let searchService = context.services.searchService
         let activity = activityPubRequest.activity
-        
+
         let objects = activity.object.objects()
         for object in objects {
             switch object.type {
-            case .note:
+            case .note, .article:
                 guard let noteDto = object.object as? NoteDto else {
                     context.logger.warning("Cannot cast note type object to NoteDto (activity: \(activity.id).")
                     continue
@@ -353,11 +353,11 @@ final class ActivityPubService: ActivityPubServiceType {
     public func update(activityPubRequest: ActivityPubRequestDto, on context: ExecutionContext) async throws {
         let statusesService = context.services.statusesService
         let activity = activityPubRequest.activity
-        
+
         let objects = activity.object.objects()
         for object in objects {
             switch object.type {
-            case .note:
+            case .note, .article:
                 guard let noteDto = object.object as? NoteDto else {
                     context.logger.warning("Cannot cast note type object to NoteDto (activity: \(activity.id).")
                     continue


### PR DESCRIPTION
## Summary

- WordPress ActivityPub plugin sends blog posts as `Article` type (not `Note`)
- This change treats Article objects the same as Note objects
- Allows WordPress blog posts with images to be displayed in Vernissage

## Changes

- `ObjectDto.swift`: Deserialize Article type as NoteDto
- `ActivityPubService.swift`: Handle Article type in `create()` and `update()` methods

## Test plan

- [ ] Follow a WordPress user with ActivityPub plugin enabled
- [ ] Verify blog posts with images appear in timeline