### PR TITLE
User blocked domains improvements

### DIFF
--- a/Sources/VernissageServer/Application+Configure.swift
+++ b/Sources/VernissageServer/Application+Configure.swift
@@ -430,6 +430,7 @@ extension Application {
         self.migrations.add(User.AddIsSupporterField())
         self.migrations.add(User.AddIncludeInSearchEngines())
         self.migrations.add(HomeCard.CreateHomeCards())
+        self.migrations.add(UserBlockedDomain.DeleteDomainUniqueIndexe())
         
         try await self.autoMigrate()
     }

--- a/Sources/VernissageServer/Constants.swift
+++ b/Sources/VernissageServer/Constants.swift
@@ -9,7 +9,7 @@ import Vapor
 /// Basic constants used in the system.
 public final class Constants {
     public static let name = "Vernissage"
-    public static let version = "1.29.0-buildx"
+    public static let version = "1.30.0-buildx"
     public static let applicationName = "\(Constants.name) \(Constants.version)"
     public static let userAgent = "(\(Constants.name)/\(Constants.version))"
     public static let requestMetadata = "Request body"

--- a/Sources/VernissageServer/Controllers/InstanceBlockedDomainsController.swift
+++ b/Sources/VernissageServer/Controllers/InstanceBlockedDomainsController.swift
@@ -28,6 +28,12 @@ extension InstanceBlockedDomainsController: RouteCollection {
         
         domainsGroup
             .grouped(XsrfTokenValidatorMiddleware())
+            .grouped(EventHandlerMiddleware(.instanceBlockedDomainsRead))
+            .grouped(CacheControlMiddleware(.noStore))
+            .get(":id", use: read)
+        
+        domainsGroup
+            .grouped(XsrfTokenValidatorMiddleware())
             .grouped(EventHandlerMiddleware(.instanceBlockedDomainsCreate))
             .grouped(CacheControlMiddleware(.noStore))
             .post(use: create)
@@ -124,6 +130,58 @@ struct InstanceBlockedDomainsController {
         )
     }
     
+    /// Read specific instance blocked domain from the database.
+    ///
+    /// The endpoint can be used for getting existing instance blocked domain.
+    ///
+    /// > Important: Endpoint URL: `/api/v1/instance-blocked-domains/:id`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/instance-blocked-domains/7267938074834522113" \
+    /// -X GET \
+    /// -H "Content-Type: application/json" \
+    /// -H "Authorization: Bearer [ACCESS_TOKEN]" \
+    /// -d '{ ... }'
+    /// ```
+    ///
+    /// **Example response body:**
+    ///
+    /// ```json
+    /// {
+    ///     "id": "7267938074834522113",
+    ///     "domain": "pornsix2.com",
+    ///     "reason": "This is a new porn website.",
+    ///     "createdAt": "2023-08-16T15:13:08.607Z",
+    ///     "updatedAt": "2024-02-09T05:12:23.479Z"
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    ///
+    /// - Returns: Instance blocked domain entity.
+    ///
+    /// - Throws: `InstanceBlockedDomainError.incorrectId` if incorrect id is specified.
+    /// - Throws: `EntityNotFoundError.instanceBlockedDomainNotFound` if instance blocked domain not found.
+    @Sendable
+    func read(request: Request) async throws -> InstanceBlockedDomainDto {
+        guard let domainIdString = request.parameters.get("id", as: String.self) else {
+            throw InstanceBlockedDomainError.incorrectId
+        }
+        
+        guard let domainId = domainIdString.toId() else {
+            throw InstanceBlockedDomainError.incorrectId
+        }
+        
+        guard let instanceBlockedDomain = try await InstanceBlockedDomain.find(domainId, on: request.db) else {
+            throw EntityNotFoundError.instanceBlockedDomainNotFound
+        }
+        
+        return InstanceBlockedDomainDto(from: instanceBlockedDomain)
+    }
+    
     /// Create new instance blocked domain.
     ///
     /// The endpoint can be used for creating new instance blocked domains.
@@ -172,7 +230,7 @@ struct InstanceBlockedDomainsController {
         
         let id = request.application.services.snowflakeService.generate()
         let instanceBlockedDomain = InstanceBlockedDomain(id: id,
-                                                          domain: instanceBlockedDomainDto.domain,
+                                                          domain: instanceBlockedDomainDto.domain.lowercased(),
                                                           reason: instanceBlockedDomainDto.reason)
 
         try await instanceBlockedDomain.save(on: request.db)
@@ -241,7 +299,7 @@ struct InstanceBlockedDomainsController {
             throw EntityNotFoundError.instanceBlockedDomainNotFound
         }
         
-        instanceBlockedDomain.domain = instanceBlockedDomainDto.domain
+        instanceBlockedDomain.domain = instanceBlockedDomainDto.domain.lowercased()
         instanceBlockedDomain.reason = instanceBlockedDomainDto.reason
 
         try await instanceBlockedDomain.save(on: request.db)

--- a/Sources/VernissageServer/Controllers/UserBlockedDomainsController.swift
+++ b/Sources/VernissageServer/Controllers/UserBlockedDomainsController.swift
@@ -26,6 +26,11 @@ extension UserBlockedDomainsController: RouteCollection {
             .get(use: list)
         
         domainsGroup
+            .grouped(EventHandlerMiddleware(.userBlockedDomainsRead))
+            .grouped(CacheControlMiddleware(.noStore))
+            .get(":id", use: read)
+        
+        domainsGroup
             .grouped(XsrfTokenValidatorMiddleware())
             .grouped(EventHandlerMiddleware(.userBlockedDomainsCreate))
             .grouped(CacheControlMiddleware(.noStore))
@@ -57,6 +62,7 @@ struct UserBlockedDomainsController {
     /// The endpoint returns a list of all user's blocked domains added to the system.
     ///
     /// Optional query params:
+    /// - `domain` - domain name to filter by
     /// - `page` - number of page to return
     /// - `size` - limit amount of returned entities on one page (default: 10)
     ///
@@ -106,7 +112,15 @@ struct UserBlockedDomainsController {
         let page: Int = request.query["page"] ?? 0
         let size: Int = request.query["size"] ?? 10
         
-        let domainsFromDatabase = try await UserBlockedDomain.query(on: request.db)
+        let authorizationPayloadId = try request.requireUserId()
+        let domainsFromDatabaseQuery = UserBlockedDomain.query(on: request.db)
+            .filter(\.$user.$id == authorizationPayloadId)
+        
+        if let domain: String = request.query["domain"] {
+            domainsFromDatabaseQuery.filter(\.$domain == domain)
+        }
+        
+        let domainsFromDatabase = try await domainsFromDatabaseQuery
             .sort(\.$domain, .ascending)
             .paginate(PageRequest(page: page, per: size))
         
@@ -120,6 +134,63 @@ struct UserBlockedDomainsController {
             size: domainsFromDatabase.metadata.per,
             total: domainsFromDatabase.metadata.total
         )
+    }
+    
+    /// Read specific user's blocked domain data.
+    ///
+    /// The endpoint returns specific user's blocked domain added to the system.
+    ///
+    /// > Important: Endpoint URL: `/api/v1/user-blocked-domains/:id`.
+    ///
+    /// **CURL request:**
+    ///
+    /// ```bash
+    /// curl "https://example.com/api/v1/user-blocked-domains/7267938074834522113" \
+    /// -X GET \
+    /// -H "Content-Type: application/json" \
+    /// -H "Authorization: Bearer [ACCESS_TOKEN]" \
+    /// ```
+    ///
+    /// **Example response body:**
+    ///
+    /// ```json
+    /// {
+    ///     "id": "7267938074834522113",
+    ///     "domain": "pornsix.com",
+    ///     "reason": "This is a porn website.",
+    ///     "createdAt": "2023-08-16T15:13:08.607Z",
+    ///     "updatedAt": "2024-02-09T05:12:23.479Z"
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - request: The Vapor request to the endpoint.
+    ///
+    /// - Returns: Object with user's blocked domain data.
+    ///
+    /// - Throws: `UserBlockedDomainError.incorrectId` if incorrect id is specified.
+    /// - Throws: `EntityNotFoundError.userBlockedDomainNotFound` if user's blocked domain not found.
+    /// - Throws: `EntityForbiddenError.userDomainBlockedForbidden` if user cannot access specific user's blocked domain.
+    @Sendable
+    func read(request: Request) async throws -> UserBlockedDomainDto {
+        guard let domainIdString = request.parameters.get("id", as: String.self) else {
+            throw UserBlockedDomainError.incorrectId
+        }
+        
+        guard let domainId = domainIdString.toId() else {
+            throw UserBlockedDomainError.incorrectId
+        }
+        
+        guard let userBlockedDomain = try await UserBlockedDomain.find(domainId, on: request.db) else {
+            throw EntityNotFoundError.userBlockedDomainNotFound
+        }
+        
+        let authorizationPayloadId = try request.requireUserId()
+        guard userBlockedDomain.$user.id == authorizationPayloadId else {
+            throw EntityForbiddenError.userDomainBlockedForbidden
+        }
+
+        return UserBlockedDomainDto(from: userBlockedDomain)
     }
     
     /// Create new user's blocked domain.
@@ -172,7 +243,7 @@ struct UserBlockedDomainsController {
         let id = request.application.services.snowflakeService.generate()
         let userBlockedDomain = UserBlockedDomain(id: id,
                                                   userId: authorizationPayloadId,
-                                                  domain: userBlockedDomainDto.domain,
+                                                  domain: userBlockedDomainDto.domain.lowercased(),
                                                   reason: userBlockedDomainDto.reason)
 
         try await userBlockedDomain.save(on: request.db)
@@ -247,7 +318,7 @@ struct UserBlockedDomainsController {
             throw EntityForbiddenError.userDomainBlockedForbidden
         }
         
-        userBlockedDomain.domain = userBlockedDomainDto.domain
+        userBlockedDomain.domain = userBlockedDomainDto.domain.lowercased()
         userBlockedDomain.reason = userBlockedDomainDto.reason
 
         try await userBlockedDomain.save(on: request.db)

--- a/Sources/VernissageServer/Extensions/Application+Seed.swift
+++ b/Sources/VernissageServer/Extensions/Application+Seed.swift
@@ -68,10 +68,7 @@ extension Application {
         try await ensureSettingExists(on: database, existing: settings, key: .isQuickCaptchaEnabled, value: .boolean(false))
 
         // Events.
-        try await ensureSettingExists(on: database,
-                                      existing: settings,
-                                      key: .eventsToStore,
-                                      value: .string(EventType.allCases.map { item -> String in item.rawValue }.joined(separator: ",")))
+        try await ensureSettingExists(on: database, existing: settings, key: .eventsToStore, value: .string(""))
 
         // JWT keys.
         let (privateKey, publicKey) = try CryptoService().generateKeys()

--- a/Sources/VernissageServer/Migrations/CreateUserBlockedDomains.swift
+++ b/Sources/VernissageServer/Migrations/CreateUserBlockedDomains.swift
@@ -7,6 +7,7 @@
 import Vapor
 import Fluent
 import SQLKit
+import SQLiteKit
 
 extension UserBlockedDomain {
     struct CreateUserBlockedDomains: AsyncMigration {
@@ -19,7 +20,6 @@ extension UserBlockedDomain {
                 .field("reason", .string)
                 .field("createdAt", .datetime)
                 .field("updatedAt", .datetime)
-                .unique(on: "domain")
                 .create()
             
             if let sqlDatabase = database as? SQLDatabase {
@@ -55,6 +55,23 @@ extension UserBlockedDomain {
                     .on(UserBlockedDomain.schema)
                     .run()
             }
+        }
+    }
+    
+    struct DeleteDomainUniqueIndexe: AsyncMigration {
+        func prepare(on database: Database) async throws {
+            // SQLite only supports adding columns in ALTER TABLE statements.
+            if let _ = database as? SQLiteDatabase {
+                return
+            }
+
+            try? await database
+                .schema(UserBlockedDomain.schema)
+                .deleteUnique(on: "domain")
+                .update()
+        }
+        
+        func revert(on database: Database) async throws {
         }
     }
 }

--- a/Sources/VernissageServer/Models/Event.swift
+++ b/Sources/VernissageServer/Models/Event.swift
@@ -182,11 +182,13 @@ enum EventType: String, Codable, CaseIterable {
     case favouritesList
     
     case instanceBlockedDomainsList
+    case instanceBlockedDomainsRead
     case instanceBlockedDomainsCreate
     case instanceBlockedDomainsUpdate
     case instanceBlockedDomainsDelete
 
     case userBlockedDomainsList
+    case userBlockedDomainsRead
     case userBlockedDomainsCreate
     case userBlockedDomainsUpdate
     case userBlockedDomainsDelete

--- a/Sources/VernissageServer/Services/ExecutionContext.swift
+++ b/Sources/VernissageServer/Services/ExecutionContext.swift
@@ -35,6 +35,10 @@ public final class ExecutionContext: Sendable {
             ?? application.logger
     }
     
+    var cache: Cache {
+        request?.cache ?? application.cache
+    }
+    
     var services: Application.Services {
         application.services
     }

--- a/Sources/VernissageServer/Services/StatusesService.swift
+++ b/Sources/VernissageServer/Services/StatusesService.swift
@@ -1624,6 +1624,9 @@ final class StatusesService: StatusesServiceType {
         // All combined shared inboxes.
         let sharedInboxesSet = Set(commonSharedInbox + followersSharedInboxes + commentatorsSharedInboxes)
         
+        // Removed blocked instances from shared inboxes where status should be sent.
+        let filteredSharedInboxes = await self.removeBlockedDomains(from: Array(sharedInboxesSet), userId: userId, on: context)
+        
         // Create array with integration information.
         let snowflakeService = context.services.snowflakeService
         let statusId = try status.requireID()
@@ -1632,7 +1635,7 @@ final class StatusesService: StatusesServiceType {
         let newStatusActivityPubEventId = snowflakeService.generate()
         let statusActivityPubEvent = StatusActivityPubEvent(id: newStatusActivityPubEventId, statusId: statusId, userId: userId, type: type)
 
-        let statusActivityPubEventItems = sharedInboxesSet.map {
+        let statusActivityPubEventItems = filteredSharedInboxes.map {
             let newStatusActivityPubEventItemId = snowflakeService.generate()
             return StatusActivityPubEventItem(id: newStatusActivityPubEventItemId, statusActivityPubEventId: newStatusActivityPubEventId, url: $0)
         }
@@ -1701,6 +1704,9 @@ final class StatusesService: StatusesServiceType {
         // Calculate followers shared inboxes.
         let followersSharedInboxes = try await self.getFollowersOfSharedInboxes(followersOf: userId, on: context)
         
+        // Removed blocked instances from shared inboxes where announce of status should be sent.
+        let filteredSharedInboxes = await self.removeBlockedDomains(from: Array(followersSharedInboxes), userId: userId, on: context)
+        
         // Create array with integration information.
         let snowflakeService = context.services.snowflakeService
         let userId = try status.user.requireID()
@@ -1708,7 +1714,7 @@ final class StatusesService: StatusesServiceType {
         let newStatusActivityPubEventId = snowflakeService.generate()
         let statusActivityPubEvent = StatusActivityPubEvent(id: newStatusActivityPubEventId, statusId: reblogStatusId, userId: userId, type: .announce)
         
-        let statusActivityPubEventItems = followersSharedInboxes.map {
+        let statusActivityPubEventItems = filteredSharedInboxes.map {
             let newStatusActivityPubEventItemId = snowflakeService.generate()
             return StatusActivityPubEventItem(id: newStatusActivityPubEventItemId, statusActivityPubEventId: newStatusActivityPubEventId, url: $0)
         }
@@ -2864,6 +2870,52 @@ final class StatusesService: StatusesServiceType {
             
             page += 1
         }
+    }
+    
+    private func removeBlockedDomains(from urls: [String], userId: Int64?, on context: ExecutionContext) async -> [String] {
+        // Download all blocked domains (for instance and user).
+        let instanceBlockedDomains = await self.getInstanceBlockedDomains(on: context)
+        let userBlockedDomains = await self.getUserBlockedDomains(for: userId, on: context)
+        let allBlockedDomains = instanceBlockedDomains + userBlockedDomains
+        
+        // Remove from urls all urls which contains blocked domains.
+        let filteredUrls = urls.compactMap { url in
+            allBlockedDomains.contains(url.host) ? nil : url
+        }
+        
+        return filteredUrls
+    }
+    
+    private func getInstanceBlockedDomains(on context: ExecutionContext) async -> [String] {
+        let instanceBlockedDomainsKey = String(describing: [InstanceBlockedDomain].self)
+        
+        // First we can get instance blocked domains from memory cache.
+        if let instanceBlockedDomainsFromCache: [String] = try? await context.cache.get(instanceBlockedDomainsKey) {
+            return instanceBlockedDomainsFromCache
+        }
+        
+        // If we don't have it in the cache we have to download them from database.
+        guard let instanceBlockedDomainsFromDatabase = try? await InstanceBlockedDomain.query(on: context.db).all() else {
+            return []
+        }
+        
+        // And store it in the cache for next requests.
+        let instanceBlockedDomains = instanceBlockedDomainsFromDatabase.map { $0.domain }
+        try? await context.cache.set(instanceBlockedDomainsKey, to: instanceBlockedDomains, expiresIn: .minutes(60))
+        
+        return instanceBlockedDomains
+    }
+    
+    private func getUserBlockedDomains(for userId: Int64?, on context: ExecutionContext) async -> [String] {
+        guard let userId else {
+            return []
+        }
+        
+        if let userBlockedDomains = try? await UserBlockedDomain.query(on: context.db).filter(\.$user.$id == userId).all() {
+            return userBlockedDomains.map { $0.domain }
+        }
+
+        return []
     }
 }
 

--- a/Tests/VernissageServerTests/AcceptanceTests/InstanceBlockedDomainsController/InstanceBlockedDomainsReadActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/InstanceBlockedDomainsController/InstanceBlockedDomainsReadActionTests.swift
@@ -1,0 +1,78 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("InstanceBlockedDomains (GET /instance-blocked-domains/:id)", .serialized, .tags(.instanceBlockedDomains))
+    struct InstanceBlockedDomainsReadActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test
+        func `Instance blocked domain should be returned for authorized user`() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "larawikol")
+            try await application.attach(user: user, role: Role.moderator)
+            let orginalInstanceBlockedDomain = try await application.createInstanceBlockedDomain(domain: "rude61.com")
+            
+            // Act.
+            let result = try await application.getResponse(
+                as: .user(userName: "larawikol", password: "p@ssword"),
+                to: "/instance-blocked-domains/" + (orginalInstanceBlockedDomain.stringId() ?? ""),
+                method: .GET,
+                decodeTo: InstanceBlockedDomainDto.self
+            )
+            
+            // Assert.
+            #expect(result.id != nil, "User blocked domain should be returned.")
+            #expect(result.domain == "rude61.com", "Correct domain should be returned.")
+        }
+        
+        @Test
+        func `Forbidden should be returned for regular user`() async throws {
+            
+            // Arrange.
+            _ = try await application.createUser(userName: "nogovikowl")
+            let orginalInstanceBlockedDomain = try await application.createInstanceBlockedDomain(domain: "rude62.com")
+                        
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "nogovikowl", password: "p@ssword"),
+                to: "/instance-blocked-domains/" + (orginalInstanceBlockedDomain.stringId() ?? ""),
+                method: .GET
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.forbidden, "Response http status code should be unauthoroized (403).")
+        }
+        
+        @Test
+        func `Unauthorize should be returned for not authorized user`() async throws {
+            
+            // Arrange.
+            let orginalInstanceBlockedDomain = try await application.createInstanceBlockedDomain(domain: "rude63.com")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/instance-blocked-domains/" + (orginalInstanceBlockedDomain.stringId() ?? ""),
+                method: .GET
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthoroized (401).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/UserBlockedDomainsController/UserBlockedDomainsCreateActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/UserBlockedDomainsController/UserBlockedDomainsCreateActionTests.swift
@@ -1,6 +1,6 @@
 //
 //  https://mczachurski.dev
-//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
 //  Licensed under the Apache License 2.0.
 //
 
@@ -39,6 +39,27 @@ extension ControllersTests {
             #expect(response.status == HTTPResponseStatus.created, "Response http status code should be created (201).")
             let instanceBlockedDomain = try await application.getUserBlockedDomain(domain: "spamiox01.com")
             #expect(instanceBlockedDomain?.reason == "This is spam", "Reason should be set correctly.")
+        }
+        
+        @Test
+        func `User blocked domain should be created with lower case only`() async throws {
+            
+            // Arrange.
+            _ = try await application.createUser(userName: "witoldvulop")
+            let userBlockedDomainDto = UserBlockedDomainDto(domain: "SPAMXXX001.com", reason: "This is spam")
+            
+            // Act.
+            let response = try await application.getResponse(
+                as: .user(userName: "witoldvulop", password: "p@ssword"),
+                to: "/user-blocked-domains",
+                method: .POST,
+                data: userBlockedDomainDto,
+                decodeTo: UserBlockedDomainDto.self
+            )
+            
+            // Assert.
+            let userBlockedDomain = try await application.getUserBlockedDomain(id: response.id?.toId() ?? 0)
+            #expect(userBlockedDomain?.domain == "spamxxx001.com", "Reason should be set correctly.")
         }
         
         @Test

--- a/Tests/VernissageServerTests/AcceptanceTests/UserBlockedDomainsController/UserBlockedDomainsDeleteActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/UserBlockedDomainsController/UserBlockedDomainsDeleteActionTests.swift
@@ -1,6 +1,6 @@
 //
 //  https://mczachurski.dev
-//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
 //  Licensed under the Apache License 2.0.
 //
 

--- a/Tests/VernissageServerTests/AcceptanceTests/UserBlockedDomainsController/UserBlockedDomainsListActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/UserBlockedDomainsController/UserBlockedDomainsListActionTests.swift
@@ -1,6 +1,6 @@
 //
 //  https://mczachurski.dev
-//  Copyright © 2025 Marcin Czachurski and the repository contributors.
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
 //  Licensed under the Apache License 2.0.
 //
 
@@ -24,9 +24,11 @@ extension ControllersTests {
         func `List of user blocked domains should be returned for user`() async throws {
             
             // Arrange.
-            let user = try await application.createUser(userName: "robinfruks")
-            _ = try await application.createUserBlockedDomain(userId: user.requireID(), domain: "pornfix1.com")
-            _ = try await application.createUserBlockedDomain(userId: user.requireID(), domain: "pornfix2.com")
+            let user1 = try await application.createUser(userName: "robinfruks")
+            let user2 = try await application.createUser(userName: "weronikafruks")
+            _ = try await application.createUserBlockedDomain(userId: user1.requireID(), domain: "pornfix1.com")
+            _ = try await application.createUserBlockedDomain(userId: user1.requireID(), domain: "pornfix2.com")
+            _ = try await application.createUserBlockedDomain(userId: user2.requireID(), domain: "pornfix3.com")
             
             // Act.
             let domains = try await application.getResponse(
@@ -37,7 +39,29 @@ extension ControllersTests {
             )
             
             // Assert.
-            #expect(domains.data.count > 0, "Some domains should be returned.")
+            #expect(domains.data.count == 2, "All user domains should be returned.")
+        }
+        
+        @Test
+        func `User blocked domains should be returned for user when filtering by domain`() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "annafruks")
+            _ = try await application.createUserBlockedDomain(userId: user.requireID(), domain: "pornfix1.com")
+            _ = try await application.createUserBlockedDomain(userId: user.requireID(), domain: "pornfix2.com")
+            _ = try await application.createUserBlockedDomain(userId: user.requireID(), domain: "pornfix3.com")
+            
+            // Act.
+            let domains = try await application.getResponse(
+                as: .user(userName: "annafruks", password: "p@ssword"),
+                to: "/user-blocked-domains?domain=pornfix2.com",
+                method: .GET,
+                decodeTo: PaginableResultDto<UserBlockedDomainDto>.self
+            )
+            
+            // Assert.
+            #expect(domains.data.count == 1, "One domains should be returned.")
+            #expect(domains.data.first?.domain == "pornfix2.com", "Correct domains should be returned.")
         }
                         
         @Test

--- a/Tests/VernissageServerTests/AcceptanceTests/UserBlockedDomainsController/UserBlockedDomainsReadActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/UserBlockedDomainsController/UserBlockedDomainsReadActionTests.swift
@@ -1,0 +1,79 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import ActivityPubKit
+import Vapor
+import Testing
+import Fluent
+
+extension ControllersTests {
+    
+    @Suite("UserBlockedDomains (GET /user-blocked-domains/:id)", .serialized, .tags(.userBlockedDomains))
+    struct UserBlockedDomainsReadActionTests {
+        var application: Application!
+        
+        init() async throws {
+            self.application = try await ApplicationManager.shared.application()
+        }
+        
+        @Test
+        func `User blocked domain should be returned for authorized user`() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "larachips")
+            let orginalUserBlockedDomain = try await application.createUserBlockedDomain(userId: user.requireID(), domain: "rude01.com")
+            
+            // Act.
+            let result = try await application.getResponse(
+                as: .user(userName: "larachips", password: "p@ssword"),
+                to: "/user-blocked-domains/" + (orginalUserBlockedDomain.stringId() ?? ""),
+                method: .GET,
+                decodeTo: UserBlockedDomainDto.self
+            )
+            
+            // Assert.
+            #expect(result.id != nil, "User blocked domain should be returned.")
+            #expect(result.domain == "rude01.com", "Correct domain should be returned.")
+        }
+        
+        @Test
+        func `Forbidden should be returned for getting somebody else blocked domain`() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "nogochips")
+            _ = try await application.createUser(userName: "tenichips")
+            let orginalUserBlockedDomain = try await application.createUserBlockedDomain(userId: user.requireID(), domain: "rude12.com")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "tenichips", password: "p@ssword"),
+                to: "/user-blocked-domains/" + (orginalUserBlockedDomain.stringId() ?? ""),
+                method: .GET
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.forbidden, "Response http status code should be unauthoroized (403).")
+        }
+        
+        @Test
+        func `Unauthorize should be returned for not authorized user`() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "yorichips")
+            let orginalUserBlockedDomain = try await application.createUserBlockedDomain(userId: user.requireID(), domain: "rude13.com")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                to: "/user-blocked-domains/" + (orginalUserBlockedDomain.stringId() ?? ""),
+                method: .GET
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthoroized (401).")
+        }
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/UserBlockedDomainsController/UserBlockedDomainsUpdateActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/UserBlockedDomainsController/UserBlockedDomainsUpdateActionTests.swift
@@ -1,6 +1,6 @@
 //
 //  https://mczachurski.dev
-//  Copyright © 2024 Marcin Czachurski and the repository contributors.
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
 //  Licensed under the Apache License 2.0.
 //
 
@@ -40,6 +40,28 @@ extension ControllersTests {
             #expect(response.status == HTTPResponseStatus.ok, "Response http status code should be created (200).")
             let userBlockedDomain = try await application.getUserBlockedDomain(domain: "rude02.com")
             #expect(userBlockedDomain?.reason == "This is spam", "Reason should be set correctly.")
+        }
+        
+        @Test
+        func `User blocked domain should be updated with lower case only`() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "witoldfionik")
+            let orginalUserBlockedDomain = try await application.createUserBlockedDomain(userId: user.requireID(), domain: "RUDEXXX001.com")
+            let userBlockedDomainDto = UserBlockedDomainDto(domain: "RUDEXXX002.com", reason: "This is spam")
+            
+            // Act.
+            let response = try await application.sendRequest(
+                as: .user(userName: "witoldfionik", password: "p@ssword"),
+                to: "/user-blocked-domains/" + (orginalUserBlockedDomain.stringId() ?? ""),
+                method: .PUT,
+                body: userBlockedDomainDto
+            )
+            
+            // Assert.
+            #expect(response.status == HTTPResponseStatus.ok, "Response http status code should be created (200).")
+            let userBlockedDomain = try await application.getUserBlockedDomain(id: orginalUserBlockedDomain.requireID())
+            #expect(userBlockedDomain?.domain == "rudexxx002.com", "Reason should be set correctly.")
         }
         
         @Test


### PR DESCRIPTION
Changes:
 - remove unique index for `domain` from `UserBlockedDoman` entity - that was a bug
 - remove blocked domains during two operations right now: (1) sending new status, (2) boosting existing status.