### PR TITLE
#469 Hide statuses from muted accounts on timelines

### DIFF
--- a/Sources/VernissageServer/Controllers/BookmarksController.swift
+++ b/Sources/VernissageServer/Controllers/BookmarksController.swift
@@ -148,7 +148,7 @@ struct BookmarksController {
         let authorizationPayloadId = try request.requireUserId()
         let linkableParams = request.linkableParams()
         let timelineService = request.application.services.timelineService
-        let statuses = try await timelineService.bookmarks(for: authorizationPayloadId, linkableParams: linkableParams, on: request.db)
+        let statuses = try await timelineService.bookmarks(for: authorizationPayloadId, linkableParams: linkableParams, on: request.executionContext)
         
         let statusesService = request.application.services.statusesService
         let statusDtos = await statusesService.convertToDtos(statuses: statuses.data, on: request.executionContext)

--- a/Sources/VernissageServer/Controllers/FavouritesController.swift
+++ b/Sources/VernissageServer/Controllers/FavouritesController.swift
@@ -148,7 +148,7 @@ struct FavouritesController {
         let authorizationPayloadId = try request.requireUserId()
         let linkableParams = request.linkableParams()
         let timelineService = request.application.services.timelineService
-        let statuses = try await timelineService.favourites(for: authorizationPayloadId, linkableParams: linkableParams, on: request.db)
+        let statuses = try await timelineService.favourites(for: authorizationPayloadId, linkableParams: linkableParams, on: request.executionContext)
         
         let statusesService = request.application.services.statusesService
         let statusDtos = await statusesService.convertToDtos(statuses: statuses.data, on: request.executionContext)

--- a/Sources/VernissageServer/Controllers/TimelinesController.swift
+++ b/Sources/VernissageServer/Controllers/TimelinesController.swift
@@ -183,8 +183,11 @@ struct TimelinesController {
         let linkableParams = request.linkableParams()
                 
         let timelineService = request.application.services.timelineService
-        let statuses = try await timelineService.public(linkableParams: linkableParams, onlyLocal: onlyLocal, on: request.db)
-        
+        let statuses = try await timelineService.public(linkableParams: linkableParams,
+                                                        onlyLocal: onlyLocal,
+                                                        forUserId: request.userId,
+                                                        on: request.executionContext)
+    
         let statusesService = request.application.services.statusesService
         let statusDtos = await statusesService.convertToDtos(statuses: statuses, on: request.executionContext)
         
@@ -332,7 +335,11 @@ struct TimelinesController {
         }
         
         let timelineService = request.application.services.timelineService
-        let statuses = try await timelineService.category(linkableParams: linkableParams, categoryId: category.requireID(), onlyLocal: onlyLocal, on: request.db)
+        let statuses = try await timelineService.category(linkableParams: linkableParams,
+                                                          categoryId: category.requireID(),
+                                                          onlyLocal: onlyLocal,
+                                                          forUserId: request.userId,
+                                                          on: request.executionContext)
         
         let statusesService = request.application.services.statusesService
         let statusDtos = await statusesService.convertToDtos(statuses: statuses, on: request.executionContext)
@@ -470,7 +477,6 @@ struct TimelinesController {
             throw ActionsForbiddenError.hashtagsForbidden
         }
 
-        
         let onlyLocal: Bool = request.query["onlyLocal"] ?? false
         let linkableParams = request.linkableParams()
         
@@ -479,8 +485,12 @@ struct TimelinesController {
         }
         
         let timelineService = request.application.services.timelineService
-        let statuses = try await timelineService.hashtags(linkableParams: linkableParams, hashtag: hashtag, onlyLocal: onlyLocal, on: request.db)
-        
+        let statuses = try await timelineService.hashtags(linkableParams: linkableParams,
+                                                          hashtag: hashtag,
+                                                          onlyLocal: onlyLocal,
+                                                          forUserId: request.userId,
+                                                          on: request.executionContext)
+
         let statusesService = request.application.services.statusesService
         let statusDtos = await statusesService.convertToDtos(statuses: statuses, on: request.executionContext)
         
@@ -615,7 +625,7 @@ struct TimelinesController {
         let linkableParams = request.linkableParams()
                 
         let timelineService = request.application.services.timelineService
-        let statuses = try await timelineService.featuredStatuses(linkableParams: linkableParams, onlyLocal: onlyLocal, on: request.db)
+        let statuses = try await timelineService.featuredStatuses(linkableParams: linkableParams, onlyLocal: onlyLocal, on: request.executionContext)
         
         let statusesService = request.application.services.statusesService
         let statusDtos = await statusesService.convertToDtos(statuses: statuses.data, on: request.executionContext)
@@ -712,7 +722,7 @@ struct TimelinesController {
         let linkableParams = request.linkableParams()
                 
         let timelineService = request.application.services.timelineService
-        let users = try await timelineService.featuredUsers(linkableParams: linkableParams, onlyLocal: onlyLocal, on: request.db)
+        let users = try await timelineService.featuredUsers(linkableParams: linkableParams, onlyLocal: onlyLocal, on: request.executionContext)
                 
         let usersService = request.application.services.usersService
         let userDtos = await usersService.convertToDtos(users: users.data, attachSensitive: false, on: request.executionContext)
@@ -842,7 +852,7 @@ struct TimelinesController {
 
         let linkableParams = request.linkableParams()
         let timelineService = request.application.services.timelineService
-        let statuses = try await timelineService.home(for: authorizationPayloadId, linkableParams: linkableParams, on: request.db)
+        let statuses = try await timelineService.home(for: authorizationPayloadId, linkableParams: linkableParams, on: request.executionContext)
         
         let statusesService = request.application.services.statusesService
         let statusDtos = await statusesService.convertToDtos(statuses: statuses.data, on: request.executionContext)

--- a/Sources/VernissageServer/Controllers/UsersController.swift
+++ b/Sources/VernissageServer/Controllers/UsersController.swift
@@ -850,12 +850,16 @@ struct UsersController {
 
                 // We have to delete all muted user statuses from the user timeline when the appropriate option has been selected.
                 if userMuteRequestDto.removeStatusesFromTimeline == true {
-                    try await timelineService.removeStatusesFromHomeTimeline(forUserId: authorizationPayloadId, byUserId: followedUser.requireID(), on: request.db)
+                    try await timelineService.removeStatusesFromHomeTimeline(forUserId: authorizationPayloadId,
+                                                                             byUserId: followedUser.requireID(),
+                                                                             on: request.executionContext)
                 }
                 
                 // We have to delete all muted user reblogs from the user timeline when the appropriate option has been selected.
                 if userMuteRequestDto.removeReblogsFromTimeline == true {
-                    try await timelineService.removeReblogsFromTimeline(forUserId: authorizationPayloadId, byUserId: followedUser.requireID(), on: request.db)
+                    try await timelineService.removeReblogsFromTimeline(forUserId: authorizationPayloadId,
+                                                                        byUserId: followedUser.requireID(),
+                                                                        on: request.executionContext)
                 }
             } catch {
                 request.logger.warning("Removing statuses from user's timeline failed. User id: \(authorizationPayloadId), follower id: \(followedUser.stringId() ?? "unknown"). Error: \(error).")
@@ -1119,12 +1123,16 @@ struct UsersController {
         
         // We have to delete all muted user statuses from the user timeline when the appropriate option has been selected.
         if userMuteRequestDto.removeStatusesFromTimeline == true {
-            try await timelineService.removeStatusesFromHomeTimeline(forUserId: authorizationPayloadId, byUserId: mutedUser.requireID(), on: request.db)
+            try await timelineService.removeStatusesFromHomeTimeline(forUserId: authorizationPayloadId,
+                                                                     byUserId: mutedUser.requireID(),
+                                                                     on: request.executionContext)
         }
         
         // We have to delete all muted user reblogs from the user timeline when the appropriate option has been selected.
         if userMuteRequestDto.removeReblogsFromTimeline == true {
-            try await timelineService.removeReblogsFromTimeline(forUserId: authorizationPayloadId, byUserId: mutedUser.requireID(), on: request.db)
+            try await timelineService.removeReblogsFromTimeline(forUserId: authorizationPayloadId,
+                                                                byUserId: mutedUser.requireID(),
+                                                                on: request.executionContext)
         }
         
         return try await self.relationship(sourceId: authorizationPayloadId, targetUser: mutedUser, on: request)

--- a/Sources/VernissageServer/Services/AtomService.swift
+++ b/Sources/VernissageServer/Services/AtomService.swift
@@ -140,7 +140,7 @@ final class AtomService: AtomServiceType {
         let baseImagesPath = storageService.getBaseImagesPath(on: context)
         
         let linkableParams = LinkableParams(maxId: nil, minId: nil, sinceId: nil, limit: self.maximumNumnerOfItems)
-        let linkableStatuses = try await timelineService.public(linkableParams: linkableParams, onlyLocal: true, on: context.db)
+        let linkableStatuses = try await timelineService.public(linkableParams: linkableParams, onlyLocal: true, forUserId: nil, on: context)
         
         // Start creating XML string.
         var xmlString = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
@@ -176,7 +176,7 @@ final class AtomService: AtomServiceType {
         let baseImagesPath = storageService.getBaseImagesPath(on: context)
         
         let linkableParams = LinkableParams(maxId: nil, minId: nil, sinceId: nil, limit: self.maximumNumnerOfItems)
-        let linkableStatuses = try await timelineService.public(linkableParams: linkableParams, onlyLocal: false, on: context.db)
+        let linkableStatuses = try await timelineService.public(linkableParams: linkableParams, onlyLocal: false, forUserId: nil, on: context)
         
         // Start creating XML string.
         var xmlString = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
@@ -248,7 +248,7 @@ final class AtomService: AtomServiceType {
         let baseImagesPath = storageService.getBaseImagesPath(on: context)
         
         let linkableParams = LinkableParams(maxId: nil, minId: nil, sinceId: nil, limit: self.maximumNumnerOfItems)
-        let linkableStatuses = try await timelineService.featuredStatuses(linkableParams: linkableParams, onlyLocal: false, on: context.db)
+        let linkableStatuses = try await timelineService.featuredStatuses(linkableParams: linkableParams, onlyLocal: false, on: context)
                 
         // Start creating XML string.
         var xmlString = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
@@ -284,7 +284,11 @@ final class AtomService: AtomServiceType {
         let baseImagesPath = storageService.getBaseImagesPath(on: context)
         
         let linkableParams = LinkableParams(maxId: nil, minId: nil, sinceId: nil, limit: self.maximumNumnerOfItems)
-        let linkableStatuses = try await timelineService.category(linkableParams: linkableParams, categoryId: category.requireID(), onlyLocal: false, on: context.db)
+        let linkableStatuses = try await timelineService.category(linkableParams: linkableParams,
+                                                                  categoryId: category.requireID(),
+                                                                  onlyLocal: false,
+                                                                  forUserId: nil,
+                                                                  on: context)
         
         // Start creating XML string.
         var xmlString = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
@@ -320,8 +324,12 @@ final class AtomService: AtomServiceType {
         let baseImagesPath = storageService.getBaseImagesPath(on: context)
         
         let linkableParams = LinkableParams(maxId: nil, minId: nil, sinceId: nil, limit: self.maximumNumnerOfItems)
-        let linkableStatuses = try await timelineService.hashtags(linkableParams: linkableParams, hashtag: hashtag, onlyLocal: false, on: context.db)
-        
+        let linkableStatuses = try await timelineService.hashtags(linkableParams: linkableParams,
+                                                                  hashtag: hashtag,
+                                                                  onlyLocal: false,
+                                                                  forUserId: nil,
+                                                                  on: context)
+
         // Start creating XML string.
         var xmlString = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
         xmlString += "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:media=\"http://search.yahoo.com/mrss/\">"

--- a/Sources/VernissageServer/Services/RssService.swift
+++ b/Sources/VernissageServer/Services/RssService.swift
@@ -143,7 +143,7 @@ final class RssService: RssServiceType {
         let baseImagesPath = storageService.getBaseImagesPath(on: context)
         
         let linkableParams = LinkableParams(maxId: nil, minId: nil, sinceId: nil, limit: self.maximumNumberOfItems)
-        let linkableStatuses = try await timelineService.public(linkableParams: linkableParams, onlyLocal: true, on: context.db)
+        let linkableStatuses = try await timelineService.public(linkableParams: linkableParams, onlyLocal: true, forUserId: nil, on: context)
         
         // Start creating XML string.
         var xmlString = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
@@ -179,7 +179,7 @@ final class RssService: RssServiceType {
         let baseImagesPath = storageService.getBaseImagesPath(on: context)
         
         let linkableParams = LinkableParams(maxId: nil, minId: nil, sinceId: nil, limit: self.maximumNumberOfItems)
-        let linkableStatuses = try await timelineService.public(linkableParams: linkableParams, onlyLocal: false, on: context.db)
+        let linkableStatuses = try await timelineService.public(linkableParams: linkableParams, onlyLocal: false, forUserId: nil, on: context)
         
         // Start creating XML string.
         var xmlString = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
@@ -251,7 +251,7 @@ final class RssService: RssServiceType {
         let baseImagesPath = storageService.getBaseImagesPath(on: context)
         
         let linkableParams = LinkableParams(maxId: nil, minId: nil, sinceId: nil, limit: self.maximumNumberOfItems)
-        let linkableStatuses = try await timelineService.featuredStatuses(linkableParams: linkableParams, onlyLocal: false, on: context.db)
+        let linkableStatuses = try await timelineService.featuredStatuses(linkableParams: linkableParams, onlyLocal: false, on: context)
         
         // Start creating XML string.
         var xmlString = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
@@ -287,7 +287,11 @@ final class RssService: RssServiceType {
         let baseImagesPath = storageService.getBaseImagesPath(on: context)
         
         let linkableParams = LinkableParams(maxId: nil, minId: nil, sinceId: nil, limit: self.maximumNumberOfItems)
-        let linkableStatuses = try await timelineService.category(linkableParams: linkableParams, categoryId: category.requireID(), onlyLocal: false, on: context.db)
+        let linkableStatuses = try await timelineService.category(linkableParams: linkableParams,
+                                                                  categoryId: category.requireID(),
+                                                                  onlyLocal: false,
+                                                                  forUserId: nil,
+                                                                  on: context)
         
         // Start creating XML string.
         var xmlString = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
@@ -323,7 +327,7 @@ final class RssService: RssServiceType {
         let baseImagesPath = storageService.getBaseImagesPath(on: context)
         
         let linkableParams = LinkableParams(maxId: nil, minId: nil, sinceId: nil, limit: self.maximumNumberOfItems)
-        let linkableStatuses = try await timelineService.hashtags(linkableParams: linkableParams, hashtag: hashtag, onlyLocal: false, on: context.db)
+        let linkableStatuses = try await timelineService.hashtags(linkableParams: linkableParams, hashtag: hashtag, onlyLocal: false, forUserId: nil, on: context)
         
         // Start creating XML string.
         var xmlString = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"

--- a/Sources/VernissageServer/Services/TimelineService.swift
+++ b/Sources/VernissageServer/Services/TimelineService.swift
@@ -29,100 +29,103 @@ protocol TimelineServiceType: Sendable {
     /// - Parameters:
     ///   - userId: Unique identifier for the user.
     ///   - linkableParams: Paging and filtering parameters.
-    ///   - database: Database to perform the query on.
+    ///   - executionContext: Context to perform the query on.
     /// - Returns: Linkable result with statuses from the home timeline.
     /// - Throws: Database errors.
-    func home(for userId: Int64, linkableParams: LinkableParams, on database: Database) async throws -> LinkableResult<Status>
+    func home(for userId: Int64, linkableParams: LinkableParams, on executionContext: ExecutionContext) async throws -> LinkableResult<Status>
     
     /// Returns statuses bookmarked by the user.
     /// - Parameters:
     ///   - userId: Unique identifier for the user.
     ///   - linkableParams: Paging and filtering parameters.
-    ///   - database: Database to perform the query on.
+    ///   - executionContext: Context to perform the query on.
     /// - Returns: Linkable result with bookmarked statuses.
     /// - Throws: Database errors.
-    func bookmarks(for userId: Int64, linkableParams: LinkableParams, on database: Database) async throws -> LinkableResult<Status>
+    func bookmarks(for userId: Int64, linkableParams: LinkableParams, on executionContext: ExecutionContext) async throws -> LinkableResult<Status>
     
     /// Returns statuses favourited by the user.
     /// - Parameters:
     ///   - userId: Unique identifier for the user.
     ///   - linkableParams: Paging and filtering parameters.
-    ///   - database: Database to perform the query on.
+    ///   - executionContext: Context to perform the query on.
     /// - Returns: Linkable result with favourited statuses.
     /// - Throws: Database errors.
-    func favourites(for userId: Int64, linkableParams: LinkableParams, on database: Database) async throws -> LinkableResult<Status>
+    func favourites(for userId: Int64, linkableParams: LinkableParams, on executionContext: ExecutionContext) async throws -> LinkableResult<Status>
     
     /// Returns public statuses with paging and optional filtering for local statuses.
     /// - Parameters:
     ///   - linkableParams: Paging and filtering parameters.
     ///   - onlyLocal: Whether to include only local statuses.
-    ///   - database: Database to perform the query on.
+    ///   - userId: Timeline filtered in context of user (filtered statuses from muted users  for example).
+    ///   - executionContext: Context to perform the query on.
     /// - Returns: Array of public statuses.
     /// - Throws: Database errors.
-    func `public`(linkableParams: LinkableParams, onlyLocal: Bool, on database: Database) async throws -> [Status]
+    func `public`(linkableParams: LinkableParams, onlyLocal: Bool, forUserId userId: Int64?, on executionContext: ExecutionContext) async throws -> [Status]
     
     /// Returns public statuses for a given category.
     /// - Parameters:
     ///   - linkableParams: Paging and filtering parameters.
     ///   - categoryId: Category identifier.
     ///   - onlyLocal: Whether to include only local statuses.
-    ///   - database: Database to perform the query on.
+    ///   - userId: Timeline filtered in context of user (filtered statuses from muted users  for example).
+    ///   - executionContext: Context to perform the query on.
     /// - Returns: Array of statuses for the category.
     /// - Throws: Database errors.
-    func category(linkableParams: LinkableParams, categoryId: Int64, onlyLocal: Bool, on database: Database) async throws -> [Status]
+    func category(linkableParams: LinkableParams, categoryId: Int64, onlyLocal: Bool, forUserId userId: Int64?, on executionContext: ExecutionContext) async throws -> [Status]
     
     /// Returns public statuses for a given hashtag.
     /// - Parameters:
     ///   - linkableParams: Paging and filtering parameters.
     ///   - hashtag: Hashtag string (normalized).
     ///   - onlyLocal: Whether to include only local statuses.
-    ///   - database: Database to perform the query on.
+    ///   - userId: Timeline filtered in context of user (filtered statuses from muted users  for example).
+    ///   - executionContext: Context to perform the query on.
     /// - Returns: Array of statuses for the hashtag.
     /// - Throws: Database errors.
-    func hashtags(linkableParams: LinkableParams, hashtag: String, onlyLocal: Bool, on database: Database) async throws -> [Status]
+    func hashtags(linkableParams: LinkableParams, hashtag: String, onlyLocal: Bool, forUserId userId: Int64?, on executionContext: ExecutionContext) async throws -> [Status]
     
     /// Returns featured statuses within the last year.
     /// - Parameters:
     ///   - linkableParams: Paging and filtering parameters.
     ///   - onlyLocal: Whether to include only local statuses.
-    ///   - database: Database to perform the query on.
+    ///   - executionContext: Context to perform the query on.
     /// - Returns: Linkable result with featured statuses.
     /// - Throws: Database errors.
-    func featuredStatuses(linkableParams: LinkableParams, onlyLocal: Bool, on database: Database) async throws -> LinkableResult<Status>
+    func featuredStatuses(linkableParams: LinkableParams, onlyLocal: Bool, on executionContext: ExecutionContext) async throws -> LinkableResult<Status>
     
     /// Returns featured users within the last year.
     /// - Parameters:
     ///   - linkableParams: Paging and filtering parameters.
     ///   - onlyLocal: Whether to include only local users.
-    ///   - database: Database to perform the query on.
+    ///   - executionContext: Context to perform the query on.
     /// - Returns: Linkable result with featured users.
     /// - Throws: Database errors.
-    func featuredUsers(linkableParams: LinkableParams, onlyLocal: Bool, on database: Database) async throws -> LinkableResult<User>
+    func featuredUsers(linkableParams: LinkableParams, onlyLocal: Bool, on executionContext: ExecutionContext) async throws -> LinkableResult<User>
     
     /// Removes from user's private timeline all statuses which has been created by followed user
     /// (directly or boosted by someone else).
     /// - Parameters:
     ///   - userId: owner of the timeline.
     ///   - authorId: author of statuses to delete.
-    ///   - database: Database to perform the query on.
+    ///   - executionContext: Context to perform the query on.
     /// - Throws: Database errors.
-    func removeStatusesFromHomeTimeline(forUserId userId: Int64, byUserId authorId: Int64, on database: Database) async throws
+    func removeStatusesFromHomeTimeline(forUserId userId: Int64, byUserId authorId: Int64, on executionContext: ExecutionContext) async throws
 
     /// Removes from user's private timeline all statuses which has been reblogged by the reblog user
     /// (statuses created by other users, but reblogged by specific user).
     /// - Parameters:
     ///   - userId: owner of the timeline.
     ///   - authorId: author of statuses to delete.
-    ///   - database: Database to perform the query on.
+    ///   - executionContext: Context to perform the query on.
     /// - Throws: Database errors.
-    func removeReblogsFromTimeline(forUserId userId: Int64, byUserId authorId: Int64, on database: Database) async throws
+    func removeReblogsFromTimeline(forUserId userId: Int64, byUserId authorId: Int64, on executionContext: ExecutionContext) async throws
 }
 
 /// A service for managing main timelines.
 final class TimelineService: TimelineServiceType {
-    func home(for userId: Int64, linkableParams: LinkableParams, on database: Database) async throws -> LinkableResult<Status> {
+    func home(for userId: Int64, linkableParams: LinkableParams, on executionContext: ExecutionContext) async throws -> LinkableResult<Status> {
 
-        var query = UserStatus.query(on: database)
+        var query = UserStatus.query(on: executionContext.db)
             .filter(\.$user.$id == userId)
             .with(\.$status) { status in
                 status.with(\.$attachments) { attachment in
@@ -173,9 +176,9 @@ final class TimelineService: TimelineServiceType {
         )
     }
     
-    func bookmarks(for userId: Int64, linkableParams: LinkableParams, on database: Database) async throws -> LinkableResult<Status> {
+    func bookmarks(for userId: Int64, linkableParams: LinkableParams, on executionContext: ExecutionContext) async throws -> LinkableResult<Status> {
 
-        var query = StatusBookmark.query(on: database)
+        var query = StatusBookmark.query(on: executionContext.db)
             .filter(\.$user.$id == userId)
             .with(\.$status) { status in
                 status.with(\.$attachments) { attachment in
@@ -226,9 +229,9 @@ final class TimelineService: TimelineServiceType {
         )
     }
     
-    func favourites(for userId: Int64, linkableParams: LinkableParams, on database: Database) async throws -> LinkableResult<Status> {
+    func favourites(for userId: Int64, linkableParams: LinkableParams, on executionContext: ExecutionContext) async throws -> LinkableResult<Status> {
 
-        var query = StatusFavourite.query(on: database)
+        var query = StatusFavourite.query(on: executionContext.db)
             .filter(\.$user.$id == userId)
             .with(\.$status) { status in
                 status.with(\.$attachments) { attachment in
@@ -279,9 +282,14 @@ final class TimelineService: TimelineServiceType {
         )
     }
     
-    func `public`(linkableParams: LinkableParams, onlyLocal: Bool = false, on database: Database) async throws -> [Status] {
-
-        var query = Status.query(on: database)
+    func `public`(linkableParams: LinkableParams,
+                  onlyLocal: Bool = false,
+                  forUserId userId: Int64? = nil,
+                  on executionContext: ExecutionContext
+    ) async throws -> [Status] {
+        let mutedUserIds = try await self.mutedUsers(forUserId: userId, on: executionContext)
+        
+        var query = Status.query(on: executionContext.db)
             .filter(\.$visibility == .public)
             .filter(\.$replyToStatus.$id == nil)
             .filter(\.$reblog.$id == nil)
@@ -324,6 +332,11 @@ final class TimelineService: TimelineServiceType {
                 .filter(\.$isLocal == true)
         }
         
+        if mutedUserIds.isEmpty == false {
+            query = query
+                .filter(\.$user.$id !~ mutedUserIds)
+        }
+        
         let statuses = try await query
             .limit(linkableParams.limit)
             .all()
@@ -331,9 +344,15 @@ final class TimelineService: TimelineServiceType {
         return statuses.sorted(by: { $0.id ?? 0 > $1.id ?? 0 })
     }
     
-    func category(linkableParams: LinkableParams, categoryId: Int64, onlyLocal: Bool = false, on database: Database) async throws -> [Status] {
+    func category(linkableParams: LinkableParams,
+                  categoryId: Int64,
+                  onlyLocal: Bool = false,
+                  forUserId userId: Int64? = nil,
+                  on executionContext: ExecutionContext
+    ) async throws -> [Status] {
+        let mutedUserIds = try await self.mutedUsers(forUserId: userId, on: executionContext)
 
-        var query = Status.query(on: database)
+        var query = Status.query(on: executionContext.db)
             .filter(\.$visibility == .public)
             .filter(\.$replyToStatus.$id == nil)
             .filter(\.$reblog.$id == nil)
@@ -377,6 +396,11 @@ final class TimelineService: TimelineServiceType {
                 .filter(\.$isLocal == true)
         }
         
+        if mutedUserIds.isEmpty == false {
+            query = query
+                .filter(\.$user.$id !~ mutedUserIds)
+        }
+        
         let statuses = try await query
             .limit(linkableParams.limit)
             .all()
@@ -384,9 +408,15 @@ final class TimelineService: TimelineServiceType {
         return statuses.sorted(by: { $0.id ?? 0 > $1.id ?? 0 })
     }
     
-    func hashtags(linkableParams: LinkableParams, hashtag: String, onlyLocal: Bool = false, on database: Database) async throws -> [Status] {
+    func hashtags(linkableParams: LinkableParams,
+                  hashtag: String,
+                  onlyLocal: Bool = false,
+                  forUserId userId: Int64? = nil,
+                  on executionContext: ExecutionContext
+    ) async throws -> [Status] {
+        let mutedUserIds = try await self.mutedUsers(forUserId: userId, on: executionContext)
 
-        var query = Status.query(on: database)
+        var query = Status.query(on: executionContext.db)
             .join(StatusHashtag.self, on: \Status.$id == \StatusHashtag.$status.$id)
             .filter(\.$visibility == .public)
             .filter(\.$replyToStatus.$id == nil)
@@ -431,6 +461,11 @@ final class TimelineService: TimelineServiceType {
                 .filter(\.$isLocal == true)
         }
         
+        if mutedUserIds.isEmpty == false {
+            query = query
+                .filter(\.$user.$id !~ mutedUserIds)
+        }
+        
         let statuses = try await query
             .limit(linkableParams.limit)
             .all()
@@ -438,8 +473,8 @@ final class TimelineService: TimelineServiceType {
         return statuses.sorted(by: { $0.id ?? 0 > $1.id ?? 0 })
     }
     
-    func featuredStatuses(linkableParams: LinkableParams, onlyLocal: Bool = false, on database: Database) async throws -> LinkableResult<Status> {
-        var query = FeaturedStatus.query(on: database)
+    func featuredStatuses(linkableParams: LinkableParams, onlyLocal: Bool = false, on executionContext: ExecutionContext) async throws -> LinkableResult<Status> {
+        var query = FeaturedStatus.query(on: executionContext.db)
             .filter(\.$createdAt > Date.yearAgo)
             .with(\.$status) { status in
                 status.with(\.$attachments) { attachment in
@@ -490,8 +525,8 @@ final class TimelineService: TimelineServiceType {
         )
     }
     
-    func featuredUsers(linkableParams: LinkableParams, onlyLocal: Bool = false, on database: Database) async throws -> LinkableResult<User> {
-        var query = FeaturedUser.query(on: database)
+    func featuredUsers(linkableParams: LinkableParams, onlyLocal: Bool = false, on executionContext: ExecutionContext) async throws -> LinkableResult<User> {
+        var query = FeaturedUser.query(on: executionContext.db)
             .with(\.$featuredUser) { featuredUser in
                 featuredUser
                     .with(\.$hashtags)
@@ -533,8 +568,8 @@ final class TimelineService: TimelineServiceType {
         )
     }
     
-    func removeStatusesFromHomeTimeline(forUserId userId: Int64, byUserId authorId: Int64, on database: Database) async throws {
-        guard let sql = database as? SQLDatabase else {
+    func removeStatusesFromHomeTimeline(forUserId userId: Int64, byUserId authorId: Int64, on executionContext: ExecutionContext) async throws {
+        guard let sql = executionContext.db as? SQLDatabase else {
             return
         }
         
@@ -561,8 +596,8 @@ final class TimelineService: TimelineServiceType {
         """).run()
     }
     
-    func removeReblogsFromTimeline(forUserId userId: Int64, byUserId authorId: Int64, on database: Database) async throws {
-        guard let sql = database as? SQLDatabase else {
+    func removeReblogsFromTimeline(forUserId userId: Int64, byUserId authorId: Int64, on executionContext: ExecutionContext) async throws {
+        guard let sql = executionContext.db as? SQLDatabase else {
             return
         }
         
@@ -576,5 +611,15 @@ final class TimelineService: TimelineServiceType {
                   AND \(ident: "s1").\(ident: "reblogId") IS NOT NULL
             )
         """).run()
+    }
+    
+    private func mutedUsers(forUserId userId: Int64?, on executionContext: ExecutionContext) async throws -> [Int64] {
+        guard let userId else {
+            return []
+        }
+        
+        let userMutesService = executionContext.services.userMutesService
+        let mutedUserIds = try await userMutesService.mutedUsers(forUserId: userId, on: executionContext.db)
+        return mutedUserIds
     }
 }

--- a/Sources/VernissageServer/Services/UserMutesService.swift
+++ b/Sources/VernissageServer/Services/UserMutesService.swift
@@ -44,6 +44,14 @@ protocol UserMutesServiceType: Sendable {
     ///   - request: The request context.
     /// - Throws: Database errors.
     func unmute(userId: Int64, mutedUserId: Int64, on request: Request) async throws
+
+    /// List of users muted by specific user..
+    /// - Parameters:
+    ///   - userId: The identifier of the user performing the mute.
+    ///   - database: The request database context.
+    /// - Returns: List of muted user's ids.
+    /// - Throws: Database errors.
+    func mutedUsers(forUserId userId: Int64, on database: Database) async throws -> [Int64]
 }
 
 /// A service for managing user mutes.
@@ -88,5 +96,20 @@ final class UserMutesService: UserMutesServiceType {
         }
         
         try await userMute.delete(on: request.db)
+    }
+    
+    func mutedUsers(forUserId userId: Int64, on database: Database) async throws -> [Int64] {
+        let userMutes = try await UserMute.query(on: database)
+            .filter(\.$user.$id == userId)
+            .filter(\.$muteStatuses == true)
+            .group(.or) { group in
+                group
+                    .filter(\.$muteEnd == nil)
+                    .filter(\.$muteEnd > Date())
+            }
+            .field(\.$mutedUser.$id)
+            .all()
+        
+        return userMutes.map({ $0.$mutedUser.id })
     }
 }

--- a/Tests/VernissageServerTests/AcceptanceTests/TimelinesController/TimelinesCategoryActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/TimelinesController/TimelinesCategoryActionTests.swift
@@ -163,5 +163,43 @@ extension ControllersTests {
             // Assert.
             #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthorized (401).")
         }
+        
+        @Test
+        func `Statuses from muted account should not be visible for authorized user`() async throws {
+            
+            // Arrange.
+            let user1 = try await application.createUser(userName: "orangefucher")
+            let user2 = try await application.createUser(userName: "brownfucher")
+            let category = try await application.getCategory(name: "Transportation")!
+            let (_, attachments1) = try await application.createStatuses(user: user1,
+                                                                         notePrefix: "Public note orangefucher",
+                                                                         categoryId: category.stringId()!,
+                                                                         amount: 2)
+            let (_, attachments2) = try await application.createStatuses(user: user2,
+                                                                         notePrefix: "Public note brownfucher",
+                                                                         categoryId: category.stringId()!,
+                                                                         amount: 2)
+            defer {
+                application.clearFiles(attachments: attachments1 + attachments2)
+            }
+            
+            _ = try await application.createUserMute(userId: user1.requireID(),
+                                                     mutedUserId: user2.requireID(),
+                                                     muteStatuses: true,
+                                                     muteReblogs: false,
+                                                     muteNotifications: false)
+            
+            // Act.
+            let statusesFromApi = try await application.getResponse(
+                as: .user(userName: "orangefucher", password: "p@ssword"),
+                to: "/timelines/category/transportation",
+                method: .GET,
+                decodeTo: LinkableResultDto<StatusDto>.self
+            )
+            
+            // Assert.
+            #expect(statusesFromApi.data.contains(where: { $0.note?.contains("orangefucher") == true }) == true, "Not muted user statuses should be visible.")
+            #expect(statusesFromApi.data.contains(where: { $0.note?.contains("brownfucher") == true }) == false, "Muted user statuses should not be visible.")
+        }
     }
 }

--- a/Tests/VernissageServerTests/AcceptanceTests/TimelinesController/TimelinesHashtagActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/TimelinesController/TimelinesHashtagActionTests.swift
@@ -136,5 +136,36 @@ extension ControllersTests {
             // Assert.
             #expect(response.status == HTTPResponseStatus.unauthorized, "Response http status code should be unauthorized (401).")
         }
+        
+        @Test
+        func `Statuses from muted account should not be visible for authorized user`() async throws {
+            
+            // Arrange.
+            let user1 = try await application.createUser(userName: "orangeredix")
+            let user2 = try await application.createUser(userName: "brownredix")
+            let (_, attachments1) = try await application.createStatuses(user: user1, notePrefix: "Public note orangeredix #mutedtest", amount: 2)
+            let (_, attachments2) = try await application.createStatuses(user: user2, notePrefix: "Public note brownredix #mutedtest", amount: 2)
+            defer {
+                application.clearFiles(attachments: attachments1 + attachments2)
+            }
+            
+            _ = try await application.createUserMute(userId: user1.requireID(),
+                                                     mutedUserId: user2.requireID(),
+                                                     muteStatuses: true,
+                                                     muteReblogs: false,
+                                                     muteNotifications: false)
+            
+            // Act.
+            let statusesFromApi = try await application.getResponse(
+                as: .user(userName: "orangeredix", password: "p@ssword"),
+                to: "/timelines/hashtag/mutedtest",
+                method: .GET,
+                decodeTo: LinkableResultDto<StatusDto>.self
+            )
+            
+            // Assert.
+            #expect(statusesFromApi.data.contains(where: { $0.note?.contains("orangeredix") == true }) == true, "Not muted user statuses should be visible.")
+            #expect(statusesFromApi.data.contains(where: { $0.note?.contains("brownredix") == true }) == false, "Muted user statuses should not be visible.")
+        }
     }
 }

--- a/Tests/VernissageServerTests/AcceptanceTests/TimelinesController/TimelinesPublicActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/TimelinesController/TimelinesPublicActionTests.swift
@@ -123,6 +123,37 @@ extension ControllersTests {
         }
         
         @Test
+        func `Statuses from muted account should not be visible for authorized user`() async throws {
+            
+            // Arrange.
+            let user1 = try await application.createUser(userName: "orangepinq")
+            let user2 = try await application.createUser(userName: "brownpinq")
+            let (_, attachments1) = try await application.createStatuses(user: user1, notePrefix: "Public note orangepinq", amount: 2)
+            let (_, attachments2) = try await application.createStatuses(user: user2, notePrefix: "Public note brownpinq", amount: 2)
+            defer {
+                application.clearFiles(attachments: attachments1 + attachments2)
+            }
+            
+            _ = try await application.createUserMute(userId: user1.requireID(),
+                                                     mutedUserId: user2.requireID(),
+                                                     muteStatuses: true,
+                                                     muteReblogs: false,
+                                                     muteNotifications: false)
+            
+            // Act.
+            let statusesFromApi = try await application.getResponse(
+                as: .user(userName: "orangepinq", password: "p@ssword"),
+                to: "/timelines/public",
+                method: .GET,
+                decodeTo: LinkableResultDto<StatusDto>.self
+            )
+            
+            // Assert.
+            #expect(statusesFromApi.data.contains(where: { $0.note?.contains("orangepinq") == true }) == true, "Not muted user statuses should be visible.")
+            #expect(statusesFromApi.data.contains(where: { $0.note?.contains("brownpinq") == true }) == false, "Muted user statuses should not be visible.")
+        }
+        
+        @Test
         func `Statuses should not be returned when public access is disabled`() async throws {
             // Arrange.
             try await application.updateSetting(key: .showLocalTimelineForAnonymous, value: .boolean(false))


### PR DESCRIPTION
Statuses published by muted accounts (mute new statuses) are hidden on timelines:
 - local
 - global (federated)
 - hashtags
 - categories