### PR TITLE
New environment VERNISSAGE_ALLOWED_HOSTS added to docker hosting documentation

### DIFF
--- a/Sources/VernissageServer/VernissageServer.docc/DockerContainers.md
+++ b/Sources/VernissageServer/VernissageServer.docc/DockerContainers.md
@@ -169,6 +169,9 @@ VERNISSAGE_QUEUEURL=redis://vernissage-redis.internal:6379
 # on your S3 storage. Normaly the same as VERNISSAGE_S3ADDRESS
 VERNISSAGE_CSP_IMG=https://minio.example.com
 
+# domain names to add to the allow list of SSRF protection rules.
+# normaly the same as in VERNISSAGE_BASEADDRESS and VERNISSAGE_S3ADDRESS
+VERNISSAGE_ALLOWED_HOSTS=vernissage.example.com,minio.example.com
 
 ########################################################################
 # PROXY


### PR DESCRIPTION
Added the new environment variable `VERNISSAGE_ALLOWED_HOSTS` as described in https://github.com/VernissageApp/VernissageWeb/issues/425 and https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf