### PR TITLE
#489 Add mechanism for suspended servers

### DIFF
--- a/Sources/VernissageServer/Application+Migrations.swift
+++ b/Sources/VernissageServer/Application+Migrations.swift
@@ -198,5 +198,7 @@ extension Application {
         self.migrations.add(UserBlockedUser.CreateUserBlockedUsers())
         self.migrations.add(Report.AddIsLocal())
         self.migrations.add(Report.AddActivityPubId())
+        self.migrations.add(SuspendedServer.CreateSuspendedServers())
+        self.migrations.add(StatusActivityPubEventItem.AddIsSuspendedField())
     }
 }

--- a/Sources/VernissageServer/Controllers/StatusActivityPubEventsController.swift
+++ b/Sources/VernissageServer/Controllers/StatusActivityPubEventsController.swift
@@ -239,7 +239,10 @@ struct StatusActivityPubEventsController {
                     
         if onlyErrors == true {
             eventItemsFromDatabaseQueryBuilder
-                .filter(\.$isSuccess == false)
+                .group(.or) { group in
+                    group.filter(\.$isSuccess == false)
+                    group.filter(\.$isSuspended == true)
+                }
         }
         
         // Read sort direction from request query string.

--- a/Sources/VernissageServer/Controllers/StatusesController.swift
+++ b/Sources/VernissageServer/Controllers/StatusesController.swift
@@ -2822,7 +2822,10 @@ struct StatusesController {
                     
         if onlyErrors == true {
             eventItemsFromDatabaseQueryBuilder
-                .filter(\.$isSuccess == false)
+                .group(.or) { group in
+                    group.filter(\.$isSuccess == false)
+                    group.filter(\.$isSuspended == true)
+                }
         }
         
         // Read sort direction from request query string.

--- a/Sources/VernissageServer/DataTransferObjects/StatusActivityPubEventItemDto.swift
+++ b/Sources/VernissageServer/DataTransferObjects/StatusActivityPubEventItemDto.swift
@@ -13,6 +13,7 @@ struct StatusActivityPubEventItemDto {
     var id: String?
     var url: String
     var isSuccess: Bool?
+    var isSuspended: Bool
     var errorMessage: String?
     var startAt: Date?
     var endAt: Date?

--- a/Sources/VernissageServer/Migrations/CreateStatusActivityPubEventItems.swift
+++ b/Sources/VernissageServer/Migrations/CreateStatusActivityPubEventItems.swift
@@ -37,4 +37,20 @@ extension StatusActivityPubEventItem {
             try await database.schema(StatusActivityPubEventItem.schema).delete()
         }
     }
+
+    struct AddIsSuspendedField: AsyncMigration {
+        func prepare(on database: Database) async throws {
+            try await database
+                .schema(StatusActivityPubEventItem.schema)
+                .field("isSuspended", .bool, .required, .sql(.default(false)))
+                .update()
+        }
+
+        func revert(on database: Database) async throws {
+            try await database
+                .schema(StatusActivityPubEventItem.schema)
+                .deleteField("isSuspended")
+                .update()
+        }
+    }
 }

--- a/Sources/VernissageServer/Migrations/CreateSuspendedServers.swift
+++ b/Sources/VernissageServer/Migrations/CreateSuspendedServers.swift
@@ -1,0 +1,30 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+import Fluent
+
+extension SuspendedServer {
+    struct CreateSuspendedServers: AsyncMigration {
+        func prepare(on database: Database) async throws {
+            try await database
+                .schema(SuspendedServer.schema)
+                .field(.id, .int64, .identifier(auto: false))
+                .field("host", .string, .required)
+                .field("hostNormalized", .string, .required)
+                .field("numberOfErrors", .int, .required)
+                .field("lastErrorDate", .datetime, .required)
+                .field("createdAt", .datetime)
+                .field("updatedAt", .datetime)
+                .unique(on: "hostNormalized")
+                .create()
+        }
+
+        func revert(on database: Database) async throws {
+            try await database.schema(SuspendedServer.schema).delete()
+        }
+    }
+}

--- a/Sources/VernissageServer/Models/StatusActivityPubEventItem.swift
+++ b/Sources/VernissageServer/Models/StatusActivityPubEventItem.swift
@@ -23,6 +23,9 @@ final class StatusActivityPubEventItem: Model, @unchecked Sendable {
 
     @Field(key: "isSuccess")
     var isSuccess: Bool?
+
+    @Field(key: "isSuspended")
+    var isSuspended: Bool
     
     @Field(key: "errorMessage")
     var errorMessage: String?
@@ -47,6 +50,7 @@ final class StatusActivityPubEventItem: Model, @unchecked Sendable {
         self.id = id
         self.$statusActivityPubEvent.id = statusActivityPubEventId
         self.url = url
+        self.isSuspended = false
     }
 }
 
@@ -56,12 +60,14 @@ extension StatusActivityPubEventItem: Content { }
 extension StatusActivityPubEventItem {
     func start(on context: ExecutionContext) async throws {
         self.startAt = Date()
+        self.isSuspended = false
         try await self.save(on: context.db)
     }
     
     func error(_ errorMessage: String, on context: ExecutionContext) async throws {
         self.endAt = Date()
         self.isSuccess = false
+        self.isSuspended = false
         self.errorMessage = errorMessage
         
         try await self.save(on: context.db)
@@ -70,6 +76,17 @@ extension StatusActivityPubEventItem {
     func success(on context: ExecutionContext) async throws {
         self.endAt = Date()
         self.isSuccess = true
+        self.isSuspended = false
+        self.errorMessage = nil
+
+        try await self.save(on: context.db)
+    }
+
+    func suspended(on context: ExecutionContext) async throws {
+        self.endAt = Date()
+        self.isSuccess = nil
+        self.isSuspended = true
+        self.errorMessage = nil
         
         try await self.save(on: context.db)
     }

--- a/Sources/VernissageServer/Models/SuspendedServer.swift
+++ b/Sources/VernissageServer/Models/SuspendedServer.swift
@@ -1,0 +1,49 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Fluent
+import Vapor
+
+/// Servers suspended after connection related errors.
+final class SuspendedServer: Model, @unchecked Sendable {
+    static let schema: String = "SuspendedServers"
+
+    @ID(custom: .id, generatedBy: .user)
+    var id: Int64?
+
+    @Field(key: "host")
+    var host: String
+
+    @Field(key: "hostNormalized")
+    var hostNormalized: String
+
+    @Field(key: "numberOfErrors")
+    var numberOfErrors: Int
+
+    @Field(key: "lastErrorDate")
+    var lastErrorDate: Date
+
+    @Timestamp(key: "createdAt", on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: "updatedAt", on: .update)
+    var updatedAt: Date?
+
+    init() { }
+
+    convenience init(id: Int64, host: String, numberOfErrors: Int, lastErrorDate: Date) {
+        self.init()
+
+        self.id = id
+        self.host = host
+        self.hostNormalized = host.uppercased()
+        self.numberOfErrors = numberOfErrors
+        self.lastErrorDate = lastErrorDate
+    }
+}
+
+/// Allows `SuspendedServer` to be encoded to and decoded from HTTP messages.
+extension SuspendedServer: Content { }

--- a/Sources/VernissageServer/Services/ActivityPubService.swift
+++ b/Sources/VernissageServer/Services/ActivityPubService.swift
@@ -895,6 +895,8 @@ final class ActivityPubService: ActivityPubServiceType {
         try await statusActivityPubEvent.start(on: context)
 
         let statusesService = context.services.statusesService
+        let suspendedServersService = context.services.suspendedServersService
+
         guard let status = try await statusesService.get(id: statusActivityPubEvent.status.requireID(), on: context.db) else {
             return
         }
@@ -910,6 +912,9 @@ final class ActivityPubService: ActivityPubServiceType {
         } else {
             nil
         }
+        
+        // Download suspended servers list.
+        let suspendedServers = await suspendedServersService.getSnapshot(on: context)
         
         // Prepare note DTO object.
         let noteDto = try await statusesService.note(basedOn: status, replyToStatus: replyToStatus, on: context)
@@ -930,6 +935,13 @@ final class ActivityPubService: ActivityPubServiceType {
                 continue
             }
 
+            let shouldSend = await suspendedServersService.shouldSend(to: sharedInboxUrl.host, basedOn: suspendedServers)
+            guard shouldSend else {
+                try? await eventItem.suspended(on: context)
+                context.logger.warning("Sending create status skipped for suspended host: '\(sharedInboxUrl.host ?? "<unknown>")'.")
+                continue
+            }
+
             // Prepare ActivityPub client.
             context.logger.info("[\(index + 1)/\(eventItemsToProceed.count)] Sending create status: '\(status.stringId() ?? "")' to shared inbox: '\(sharedInboxUrl.absoluteString)'.")
             let activityPubClient = ActivityPubClient(privatePemKey: privateKey, userAgent: Constants.userAgent, host: sharedInboxUrl.host)
@@ -943,15 +955,17 @@ final class ActivityPubService: ActivityPubServiceType {
                 
                 // Mark event item as finished successfully.
                 try? await eventItem.success(on: context)
+                try? await suspendedServersService.registerSuccess(for: sharedInboxUrl.host, on: context)
             } catch {
                 // Mark event item as finished with error.
                 try? await eventItem.error("\(error)", on: context)
+                try? await suspendedServersService.registerConnectionError(for: sharedInboxUrl.host, error: error, on: context)
                 context.logger.warning("Sending create status to shared inbox error. Shared inbox url: \(sharedInboxUrl). Error: \(error).")
             }
         }
         
         // Mark event as finished successfully.
-        let hasFailedEvents = statusActivityPubEvent.statusActivityPubEventItems.contains(where: { $0.isSuccess == false })
+        let hasFailedEvents = statusActivityPubEvent.statusActivityPubEventItems.contains(where: { $0.isSuccess == false || $0.isSuspended == true })
         try await statusActivityPubEvent.success(result: hasFailedEvents ? .finishedWithErrors : .finished, on: context)
     }
     
@@ -959,6 +973,8 @@ final class ActivityPubService: ActivityPubServiceType {
         try await statusActivityPubEvent.start(on: context)
 
         let statusesService = context.services.statusesService
+        let suspendedServersService = context.services.suspendedServersService
+
         guard let status = try await statusesService.get(id: statusActivityPubEvent.status.requireID(), on: context.db) else {
             return
         }
@@ -980,6 +996,9 @@ final class ActivityPubService: ActivityPubServiceType {
             nil
         }
         
+        // Download suspended servers list.
+        let suspendedServers = await suspendedServersService.getSnapshot(on: context)
+        
         // Prepare note DTO object.
         let noteDto = try await statusesService.note(basedOn: status, replyToStatus: replyToStatus, on: context)
 
@@ -999,6 +1018,13 @@ final class ActivityPubService: ActivityPubServiceType {
                 continue
             }
 
+            let shouldSend = await suspendedServersService.shouldSend(to: sharedInboxUrl.host, basedOn: suspendedServers)
+            guard shouldSend else {
+                try? await eventItem.suspended(on: context)
+                context.logger.warning("Sending update status skipped for suspended host: '\(sharedInboxUrl.host ?? "<unknown>")'.")
+                continue
+            }
+
             // Prepare ActivityPub client.
             context.logger.info("[\(index + 1)/\(eventItemsToProceed.count)] Sending update status: '\(status.stringId() ?? "")' to shared inbox: '\(sharedInboxUrl.absoluteString)'.")
             let activityPubClient = ActivityPubClient(privatePemKey: privateKey, userAgent: Constants.userAgent, host: sharedInboxUrl.host)
@@ -1014,15 +1040,17 @@ final class ActivityPubService: ActivityPubServiceType {
                 
                 // Mark event item as finished successfully.
                 try? await eventItem.success(on: context)
+                try? await suspendedServersService.registerSuccess(for: sharedInboxUrl.host, on: context)
             } catch {
                 // Mark event item as finished with error.
                 try? await eventItem.error("\(error)", on: context)
+                try? await suspendedServersService.registerConnectionError(for: sharedInboxUrl.host, error: error, on: context)
                 context.logger.warning("Sending update status to shared inbox error. Shared inbox url: \(sharedInboxUrl). Error: \(error).")
             }
         }
         
         // Mark event as finished successfully.
-        let hasFailedEvents = statusActivityPubEvent.statusActivityPubEventItems.contains(where: { $0.isSuccess == false })
+        let hasFailedEvents = statusActivityPubEvent.statusActivityPubEventItems.contains(where: { $0.isSuccess == false || $0.isSuspended == true })
         try await statusActivityPubEvent.success(result: hasFailedEvents ? .finishedWithErrors : .finished, on: context)
     }
     
@@ -1036,6 +1064,7 @@ final class ActivityPubService: ActivityPubServiceType {
         
         let statusesService = context.services.statusesService
         let usersService = context.services.usersService
+        let suspendedServersService = context.services.suspendedServersService
         
         guard let status = try await statusesService.get(id: statusActivityPubEvent.status.requireID(), on: context.db) else {
             return
@@ -1055,6 +1084,9 @@ final class ActivityPubService: ActivityPubServiceType {
             return
         }
         
+        // Download suspended servers list.
+        let suspendedServers = await suspendedServersService.getSnapshot(on: context)
+        
         // Try to send update only to hosts which we didn't sent update yet.
         let eventItemsToProceed = statusActivityPubEvent.statusActivityPubEventItems.filter { $0.isSuccess == nil }
 
@@ -1071,6 +1103,13 @@ final class ActivityPubService: ActivityPubServiceType {
                 continue
             }
             
+            let shouldSend = await suspendedServersService.shouldSend(to: sharedInboxUrl.host, basedOn: suspendedServers)
+            guard shouldSend else {
+                try? await eventItem.suspended(on: context)
+                context.logger.warning("Sending favourite skipped for suspended host: '\(sharedInboxUrl.host ?? "<unknown>")'.")
+                continue
+            }
+
             // Prepare ActivityPub client.
             context.logger.info("[\(index + 1)/\(eventItemsToProceed.count)] Sending favourite: '\(statusFavouriteId)' to shared inbox: '\(sharedInboxUrl.absoluteString)'.")
             let activityPubClient = ActivityPubClient(privatePemKey: privateKey, userAgent: Constants.userAgent, host: sharedInboxUrl.host)
@@ -1084,15 +1123,17 @@ final class ActivityPubService: ActivityPubServiceType {
                 
                 // Mark event item as finished successfully.
                 try? await eventItem.success(on: context)
+                try? await suspendedServersService.registerSuccess(for: sharedInboxUrl.host, on: context)
             } catch {
                 // Mark event item as finished with error.
                 try? await eventItem.error("\(error)", on: context)
+                try? await suspendedServersService.registerConnectionError(for: sharedInboxUrl.host, error: error, on: context)
                 context.logger.warning("Sending favourite to shared inbox error. Shared inbox url: \(sharedInboxUrl). Error: \(error).")
             }
         }
         
         // Mark event as finished successfully.
-        let hasFailedEvents = statusActivityPubEvent.statusActivityPubEventItems.contains(where: { $0.isSuccess == false })
+        let hasFailedEvents = statusActivityPubEvent.statusActivityPubEventItems.contains(where: { $0.isSuccess == false || $0.isSuspended == true })
         try await statusActivityPubEvent.success(result: hasFailedEvents ? .finishedWithErrors : .finished, on: context)
     }
     
@@ -1106,6 +1147,7 @@ final class ActivityPubService: ActivityPubServiceType {
         
         let statusesService = context.services.statusesService
         let usersService = context.services.usersService
+        let suspendedServersService = context.services.suspendedServersService
         
         guard let status = try await statusesService.get(id: statusActivityPubEvent.status.requireID(), on: context.db) else {
             return
@@ -1125,6 +1167,9 @@ final class ActivityPubService: ActivityPubServiceType {
             return
         }
         
+        // Download suspended servers list.
+        let suspendedServers = await suspendedServersService.getSnapshot(on: context)
+        
         // Try to send update only to hosts which we didn't sent update yet.
         let eventItemsToProceed = statusActivityPubEvent.statusActivityPubEventItems.filter { $0.isSuccess == nil }
 
@@ -1141,6 +1186,13 @@ final class ActivityPubService: ActivityPubServiceType {
                 continue
             }
             
+            let shouldSend = await suspendedServersService.shouldSend(to: sharedInboxUrl.host, basedOn: suspendedServers)
+            guard shouldSend else {
+                try? await eventItem.suspended(on: context)
+                context.logger.warning("Sending unfavourite skipped for suspended host: '\(sharedInboxUrl.host ?? "<unknown>")'.")
+                continue
+            }
+
             // Prepare ActivityPub client.
             context.logger.info("[\(index + 1)/\(eventItemsToProceed.count)] Sending unfavourite: '\(statusFavouriteId)' to shared inbox: '\(sharedInboxUrl.absoluteString)'.")
             let activityPubClient = ActivityPubClient(privatePemKey: privateKey, userAgent: Constants.userAgent, host: sharedInboxUrl.host)
@@ -1154,15 +1206,17 @@ final class ActivityPubService: ActivityPubServiceType {
                 
                 // Mark event item as finished successfully.
                 try? await eventItem.success(on: context)
+                try? await suspendedServersService.registerSuccess(for: sharedInboxUrl.host, on: context)
             } catch {
                 // Mark event item as finished with error.
                 try? await eventItem.error("\(error)", on: context)
+                try? await suspendedServersService.registerConnectionError(for: sharedInboxUrl.host, error: error, on: context)
                 context.logger.warning("Sending unfavourite to shared inbox error. Shared inbox url: \(sharedInboxUrl). Error: \(error).")
             }
         }
         
         // Mark event as finished successfully.
-        let hasFailedEvents = statusActivityPubEvent.statusActivityPubEventItems.contains(where: { $0.isSuccess == false })
+        let hasFailedEvents = statusActivityPubEvent.statusActivityPubEventItems.contains(where: { $0.isSuccess == false || $0.isSuspended == true })
         try await statusActivityPubEvent.success(result: hasFailedEvents ? .finishedWithErrors : .finished, on: context)
     }
     
@@ -1175,6 +1229,8 @@ final class ActivityPubService: ActivityPubServiceType {
         }
         
         let statusesService = context.services.statusesService
+        let suspendedServersService = context.services.suspendedServersService
+
         guard let status = try await statusesService.get(id: statusActivityPubEvent.status.requireID(), on: context.db) else {
             return
         }
@@ -1188,6 +1244,9 @@ final class ActivityPubService: ActivityPubServiceType {
             context.logger.warning("\(errorMessage)")
             return
         }
+        
+        // Download suspended servers list.
+        let suspendedServers = await suspendedServersService.getSnapshot(on: context)
         
         // Try to send update only to hosts which we didn't sent update yet.
         let eventItemsToProceed = statusActivityPubEvent.statusActivityPubEventItems.filter { $0.isSuccess == nil }
@@ -1205,6 +1264,13 @@ final class ActivityPubService: ActivityPubServiceType {
                 continue
             }
             
+            let shouldSend = await suspendedServersService.shouldSend(to: sharedInboxUrl.host, basedOn: suspendedServers)
+            guard shouldSend else {
+                try? await eventItem.suspended(on: context)
+                context.logger.warning("Sending announce skipped for suspended host: '\(sharedInboxUrl.host ?? "<unknown>")'.")
+                continue
+            }
+
             // Prepare ActivityPub client.
             context.logger.info("[\(index + 1)/\(eventItemsToProceed.count)] Sending announce: '\(activityPubReblog.activityPubStatusId)' (orginal status id: '\(status.stringId() ?? "")') to shared inbox: '\(sharedInboxUrl.absoluteString)'.")
             let activityPubClient = ActivityPubClient(privatePemKey: privateKey, userAgent: Constants.userAgent, host: sharedInboxUrl.host)
@@ -1220,15 +1286,17 @@ final class ActivityPubService: ActivityPubServiceType {
                 
                 // Mark event item as finished successfully.
                 try? await eventItem.success(on: context)
+                try? await suspendedServersService.registerSuccess(for: sharedInboxUrl.host, on: context)
             } catch {
                 // Mark event item as finished with error.
                 try? await eventItem.error("\(error)", on: context)
+                try? await suspendedServersService.registerConnectionError(for: sharedInboxUrl.host, error: error, on: context)
                 context.logger.warning("Sending announce to shared inbox error. Shared inbox url: \(sharedInboxUrl). Error: \(error).")
             }
         }
         
         // Mark event as finished successfully.
-        let hasFailedEvents = statusActivityPubEvent.statusActivityPubEventItems.contains(where: { $0.isSuccess == false })
+        let hasFailedEvents = statusActivityPubEvent.statusActivityPubEventItems.contains(where: { $0.isSuccess == false || $0.isSuspended == true })
         try await statusActivityPubEvent.success(result: hasFailedEvents ? .finishedWithErrors : .finished, on: context)
     }
     
@@ -1241,6 +1309,8 @@ final class ActivityPubService: ActivityPubServiceType {
         }
         
         let statusesService = context.services.statusesService
+        let suspendedServersService = context.services.suspendedServersService
+
         guard let status = try await statusesService.get(id: statusActivityPubEvent.status.requireID(), on: context.db) else {
             return
         }
@@ -1255,6 +1325,9 @@ final class ActivityPubService: ActivityPubServiceType {
             context.logger.warning("\(errorMessage)")
             return
         }
+        
+        // Download suspended servers list.
+        let suspendedServers = await suspendedServersService.getSnapshot(on: context)
         
         // Try to send update only to hosts which we didn't sent update yet.
         let eventItemsToProceed = statusActivityPubEvent.statusActivityPubEventItems.filter { $0.isSuccess == nil }
@@ -1272,6 +1345,13 @@ final class ActivityPubService: ActivityPubServiceType {
                 continue
             }
             
+            let shouldSend = await suspendedServersService.shouldSend(to: sharedInboxUrl.host, basedOn: suspendedServers)
+            guard shouldSend else {
+                try? await eventItem.suspended(on: context)
+                context.logger.warning("Sending unannounce skipped for suspended host: '\(sharedInboxUrl.host ?? "<unknown>")'.")
+                continue
+            }
+
             // Prepare ActivityPub client.
             context.logger.info("[\(index + 1)/\(eventItemsToProceed.count)] Sending unannounce: '\(activityPubUnreblog.activityPubStatusId)' (orginal status id: '\(status.stringId() ?? "")') to shared inbox: '\(sharedInboxUrl.absoluteString)'.")
             let activityPubClient = ActivityPubClient(privatePemKey: privateKey, userAgent: Constants.userAgent, host: sharedInboxUrl.host)
@@ -1287,15 +1367,17 @@ final class ActivityPubService: ActivityPubServiceType {
                 
                 // Mark event item as finished successfully.
                 try? await eventItem.success(on: context)
+                try? await suspendedServersService.registerSuccess(for: sharedInboxUrl.host, on: context)
             } catch {
                 // Mark event item as finished with error.
                 try? await eventItem.error("\(error)", on: context)
+                try? await suspendedServersService.registerConnectionError(for: sharedInboxUrl.host, error: error, on: context)
                 context.logger.warning("Sending unannounce to shared inbox error. Shared inbox url: \(sharedInboxUrl). Error: \(error).")
             }
         }
         
         // Mark event as finished successfully.
-        let hasFailedEvents = statusActivityPubEvent.statusActivityPubEventItems.contains(where: { $0.isSuccess == false })
+        let hasFailedEvents = statusActivityPubEvent.statusActivityPubEventItems.contains(where: { $0.isSuccess == false || $0.isSuspended == true })
         try await statusActivityPubEvent.success(result: hasFailedEvents ? .finishedWithErrors : .finished, on: context)
     }
     

--- a/Sources/VernissageServer/Services/StatusesService.swift
+++ b/Sources/VernissageServer/Services/StatusesService.swift
@@ -1996,6 +1996,7 @@ final class StatusesService: StatusesServiceType {
                 id: statusActivityPubEventItem.stringId(),
                 url: statusActivityPubEventItem.url,
                 isSuccess: statusActivityPubEventItem.isSuccess,
+                isSuspended: statusActivityPubEventItem.isSuspended,
                 errorMessage: statusActivityPubEventItem.errorMessage,
                 startAt: statusActivityPubEventItem.startAt,
                 endAt: statusActivityPubEventItem.endAt,
@@ -3014,4 +3015,3 @@ final class StatusesService: StatusesServiceType {
         return []
     }
 }
-

--- a/Sources/VernissageServer/Services/SuspendedServersService.swift
+++ b/Sources/VernissageServer/Services/SuspendedServersService.swift
@@ -91,10 +91,13 @@ actor SuspendedServersService: SuspendedServersServiceType {
         ENETDOWN,
         ENOTCONN
     ]
+    
+    private let connectionErrorCodeRawValues: Set<Int>
 
     init(maxNumberOfErrors: Int = 10, suspensionPeriod: TimeInterval = 24 * 60 * 60) {
         self.maxNumberOfErrors = maxNumberOfErrors
         self.suspensionPeriod = suspensionPeriod
+        self.connectionErrorCodeRawValues = Set(self.connectionErrorCodes.map(\.rawValue))
     }
 
     func getSnapshot(on context: ExecutionContext) async -> [SuspendedServer] {
@@ -201,11 +204,9 @@ actor SuspendedServersService: SuspendedServersServiceType {
 
         let nsError = error as NSError
 
-        if nsError.domain == NSURLErrorDomain {
-            let urlErrorCode = URLError.Code(rawValue: nsError.code)
-            if self.connectionErrorCodes.contains(urlErrorCode) {
-                return true
-            }
+        if nsError.domain == NSURLErrorDomain,
+           self.connectionErrorCodeRawValues.contains(nsError.code) {
+            return true
         }
 
         if nsError.domain == NSPOSIXErrorDomain,

--- a/Sources/VernissageServer/Services/SuspendedServersService.swift
+++ b/Sources/VernissageServer/Services/SuspendedServersService.swift
@@ -1,0 +1,222 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Vapor
+import Fluent
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+extension Application.Services {
+    struct SuspendedServersServiceKey: StorageKey {
+        typealias Value = SuspendedServersServiceType
+    }
+
+    var suspendedServersService: SuspendedServersServiceType {
+        get {
+            self.application.storage[SuspendedServersServiceKey.self] ?? SuspendedServersService()
+        }
+        nonmutating set {
+            self.application.storage[SuspendedServersServiceKey.self] = newValue
+        }
+    }
+}
+
+@_documentation(visibility: private)
+protocol SuspendedServersServiceType: Sendable {
+    /// Reads suspended servers for current sending iteration.
+    ///
+    /// - Parameter context: Execution context.
+    /// - Returns: List with suspended servers state.
+    func getSnapshot(on context: ExecutionContext) async -> [SuspendedServer]
+
+    /// Checks if request can be sent to host.
+    ///
+    /// - Parameters:
+    ///   - host: Host name from URL.
+    ///   - suspendedServers: List loaded for current iteration.
+    /// - Returns: `false` when host is temporarily suspended.
+    func shouldSend(to host: String?, basedOn suspendedServers: [SuspendedServer]) async -> Bool
+
+    /// Registers connection related error for host.
+    ///
+    /// - Parameters:
+    ///   - host: Host name from URL.
+    ///   - error: Error returned during request.
+    ///   - context: Execution context.
+    /// - Throws: Database errors.
+    func registerConnectionError(for host: String?, error: Error, on context: ExecutionContext) async throws
+
+    /// Removes host from suspended list after successful request.
+    ///
+    /// - Parameters:
+    ///   - host: Host name from URL.
+    ///   - context: Execution context.
+    /// - Throws: Database errors.
+    func registerSuccess(for host: String?, on context: ExecutionContext) async throws
+}
+
+/// A service responsible for managing temporarily suspended remote servers.
+actor SuspendedServersService: SuspendedServersServiceType {
+    private let maxNumberOfErrors: Int
+    private let suspensionPeriod: TimeInterval
+
+    private let connectionErrorCodes: Set<URLError.Code> = [
+        .timedOut,
+        .cannotFindHost,
+        .cannotConnectToHost,
+        .networkConnectionLost,
+        .dnsLookupFailed,
+        .notConnectedToInternet,
+        .resourceUnavailable,
+        .cannotLoadFromNetwork
+    ]
+
+    private let connectionPosixCodes: Set<Int32> = [
+        ECONNREFUSED,
+        ECONNRESET,
+        ETIMEDOUT,
+        EHOSTUNREACH,
+        ENETUNREACH,
+        ENETDOWN,
+        ENOTCONN
+    ]
+
+    init(maxNumberOfErrors: Int = 10, suspensionPeriod: TimeInterval = 24 * 60 * 60) {
+        self.maxNumberOfErrors = maxNumberOfErrors
+        self.suspensionPeriod = suspensionPeriod
+    }
+
+    func getSnapshot(on context: ExecutionContext) async -> [SuspendedServer] {
+        if let suspendedServers = try? await SuspendedServer.query(on: context.db).all() {
+            return suspendedServers
+        }
+
+        return []
+    }
+
+    func shouldSend(to host: String?, basedOn suspendedServers: [SuspendedServer]) async -> Bool {
+        guard let hostNormalized = self.normalizedHost(from: host) else {
+            return true
+        }
+
+        guard let suspendedServer = suspendedServers.first(where: { $0.hostNormalized == hostNormalized }) else {
+            return true
+        }
+
+        if suspendedServer.numberOfErrors < self.maxNumberOfErrors {
+            return true
+        }
+
+        let retryDate = suspendedServer.lastErrorDate.addingTimeInterval(self.suspensionPeriod)
+        return retryDate <= Date()
+    }
+
+    func registerConnectionError(for host: String?, error: Error, on context: ExecutionContext) async throws {
+        guard let host,
+              let hostNormalized = self.normalizedHost(from: host),
+              self.isConnectionError(error) else {
+            return
+        }
+
+        let lastErrorDate = Date()
+        let suspendedServerFromDatabase = try await SuspendedServer.query(on: context.db)
+            .filter(\.$hostNormalized == hostNormalized)
+            .first()
+
+        if let suspendedServerFromDatabase {
+            suspendedServerFromDatabase.numberOfErrors += 1
+            suspendedServerFromDatabase.lastErrorDate = lastErrorDate
+
+            try await suspendedServerFromDatabase.save(on: context.db)
+            return
+        }
+
+        let id = context.services.snowflakeService.generate()
+        let newSuspendedServer = SuspendedServer(id: id,
+                                              host: host,
+                                              numberOfErrors: 1,
+                                              lastErrorDate: lastErrorDate)
+        do {
+            try await newSuspendedServer.save(on: context.db)
+        } catch {
+            // If another service instance inserted row in parallel, update existing row.
+            let existingSuspendedServer = try await SuspendedServer.query(on: context.db)
+                .filter(\.$hostNormalized == hostNormalized)
+                .first()
+
+            if let existingSuspendedServer {
+                existingSuspendedServer.numberOfErrors += 1
+                existingSuspendedServer.lastErrorDate = lastErrorDate
+
+                try await existingSuspendedServer.save(on: context.db)
+                return
+            }
+
+            throw error
+        }
+    }
+
+    func registerSuccess(for host: String?, on context: ExecutionContext) async throws {
+        guard let hostNormalized = self.normalizedHost(from: host) else {
+            return
+        }
+
+        let suspendedServer = try await SuspendedServer.query(on: context.db)
+            .filter(\.$hostNormalized == hostNormalized)
+            .first()
+        
+        if let suspendedServer {
+            try await suspendedServer.delete(on: context.db)
+        }
+    }
+
+    private func normalizedHost(from host: String?) -> String? {
+        guard let host else {
+            return nil
+        }
+
+        let trimmedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedHost.isEmpty == false else {
+            return nil
+        }
+
+        return trimmedHost.uppercased()
+    }
+
+    private func isConnectionError(_ error: Error) -> Bool {
+        if let urlError = error as? URLError {
+            return self.connectionErrorCodes.contains(urlError.code)
+        }
+
+        let nsError = error as NSError
+
+        if nsError.domain == NSURLErrorDomain {
+            let urlErrorCode = URLError.Code(rawValue: nsError.code)
+            if self.connectionErrorCodes.contains(urlErrorCode) {
+                return true
+            }
+        }
+
+        if nsError.domain == NSPOSIXErrorDomain,
+           self.connectionPosixCodes.contains(Int32(nsError.code)) {
+            return true
+        }
+
+        if let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
+            return self.isConnectionError(underlyingError)
+        }
+
+        return false
+    }
+}

--- a/Tests/VernissageServerTests/AcceptanceTests/StatusActivityPubEventsController/StatusActivityPubEventsItemsActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/StatusActivityPubEventsController/StatusActivityPubEventsItemsActionTests.swift
@@ -77,6 +77,41 @@ extension ControllersTests {
             #expect(events.total == 12, "Correct total events should be returned.")
             #expect(events.data.count == 10, "Correct events list should be returned.")
         }
+
+        @Test
+        func `Only error and suspended items should be returned for only errors filter`() async throws {
+            
+            // Arrange.
+            let administrator = try await application.createUser(userName: "karolbenny")
+            let user = try await application.createUser(userName: "martabenny")
+            try await application.attach(user: administrator, role: Role.administrator)
+            
+            let attachment = try await application.createAttachment(user: user)
+            let status = try await application.createStatus(user: user, note: "Note with events", attachmentIds: [attachment.stringId()!], visibility: .public)
+            defer {
+                application.clearFiles(attachments: [attachment])
+            }
+            
+            let event = try await application.createStatusActivityPubEvent(statusId: status.requireID(),
+                                                                           userId: user.requireID(),
+                                                                           type: .create,
+                                                                           numberOfSuccessItems: 4,
+                                                                           numberOfErrorItems: 6,
+                                                                           numberOfSuspendedItems: 9)
+            
+            // Act.
+            let events = try await application.getResponse(
+                as: .user(userName: "karolbenny", password: "p@ssword"),
+                to: "/status-activity-pub-events/\(event.requireID())/items?onlyErrors=true&size=30",
+                method: .GET,
+                decodeTo: PaginableResultDto<StatusActivityPubEventItemDto>.self
+            )
+            
+            // Assert.
+            #expect(events.total == 15, "Only error and suspended items should be returned.")
+            #expect(events.data.count == 15, "Returned list should contain only error and suspended items.")
+            #expect(events.data.contains(where: { $0.isSuspended == true }), "At least one suspended item should be returned.")
+        }
         
         @Test
         func `Forbidden should be returned for regulat user`() async throws {

--- a/Tests/VernissageServerTests/AcceptanceTests/StatusesController/StatusesEventItemsListActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/StatusesController/StatusesEventItemsListActionTests.swift
@@ -129,6 +129,38 @@ extension ControllersTests {
             #expect(events.total == 14, "Correct total events should be returned.")
             #expect(events.data.count == 10, "Correct events list should be returned.")
         }
+
+        @Test
+        func `Only error and suspended items should be returned for only errors filter`() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "bernardgrubson")
+            let attachment = try await application.createAttachment(user: user)
+            let status = try await application.createStatus(user: user, note: "Note with events", attachmentIds: [attachment.stringId()!], visibility: .public)
+            defer {
+                application.clearFiles(attachments: [attachment])
+            }
+            
+            let event = try await application.createStatusActivityPubEvent(statusId: status.requireID(),
+                                                                           userId: user.requireID(),
+                                                                           type: .create,
+                                                                           numberOfSuccessItems: 5,
+                                                                           numberOfErrorItems: 7,
+                                                                           numberOfSuspendedItems: 8)
+            
+            // Act.
+            let events = try await application.getResponse(
+                as: .user(userName: "bernardgrubson", password: "p@ssword"),
+                to: "/statuses/\(status.requireID())/events/\(event.requireID())/items?onlyErrors=true&size=30",
+                method: .GET,
+                decodeTo: PaginableResultDto<StatusActivityPubEventItemDto>.self
+            )
+            
+            // Assert.
+            #expect(events.total == 15, "Only error and suspended items should be returned.")
+            #expect(events.data.count == 15, "Returned list should contain only error and suspended items.")
+            #expect(events.data.contains(where: { $0.isSuspended == true }), "At least one suspended item should be returned.")
+        }
         
         @Test
         func `Forbidden should be returned for someone else status events`() async throws {

--- a/Tests/VernissageServerTests/Helpers/Extensions/StatusActivityPubEvent.swift
+++ b/Tests/VernissageServerTests/Helpers/Extensions/StatusActivityPubEvent.swift
@@ -13,7 +13,8 @@ extension Application {
                                       userId: Int64,
                                       type: StatusActivityPubEventType,
                                       numberOfSuccessItems: Int = 1,
-                                      numberOfErrorItems: Int = 0) async throws -> StatusActivityPubEvent {
+                                      numberOfErrorItems: Int = 0,
+                                      numberOfSuspendedItems: Int = 0) async throws -> StatusActivityPubEvent {
         let newStatusActivityPubEventId = await ApplicationManager.shared.generateId()
         let statusActivityPubEvent = StatusActivityPubEvent(id: newStatusActivityPubEventId, statusId: statusId, userId: userId, type: type, eventContext: "")
         try await statusActivityPubEvent.save(on: self.db)
@@ -33,6 +34,18 @@ extension Application {
                                                                         url: "https://localhost/shared-status/\(index)")
             statusActivityPubEventItem.isSuccess = false
             statusActivityPubEventItem.errorMessage = "Error"
+
+            try await statusActivityPubEventItem.save(on: self.db)
+        }
+
+        for index in 0..<numberOfSuspendedItems {
+            let newStatusActivityPubEventItemId = await ApplicationManager.shared.generateId()
+            let statusActivityPubEventItem = StatusActivityPubEventItem(id: newStatusActivityPubEventItemId,
+                                                                        statusActivityPubEventId: newStatusActivityPubEventId,
+                                                                        url: "https://localhost/suspended-status/\(index)")
+            statusActivityPubEventItem.isSuccess = nil
+            statusActivityPubEventItem.isSuspended = true
+            statusActivityPubEventItem.errorMessage = nil
 
             try await statusActivityPubEventItem.save(on: self.db)
         }

--- a/Tests/VernissageServerTests/Helpers/Extensions/SuspendedServer.swift
+++ b/Tests/VernissageServerTests/Helpers/Extensions/SuspendedServer.swift
@@ -1,0 +1,22 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import Vapor
+import Fluent
+
+extension Application {
+    func clearSuspendedServers() async throws {
+        let all = try await SuspendedServer.query(on: self.db).all()
+        try await all.delete(on: self.db)
+    }
+
+    func getSuspendedServer(hostNormalized: String) async throws -> SuspendedServer? {
+        return try await SuspendedServer.query(on: self.db)
+            .filter(\.$hostNormalized == hostNormalized)
+            .first()
+    }
+}

--- a/Tests/VernissageServerTests/ServicesTests/StatusActivityPubEventItemTests.swift
+++ b/Tests/VernissageServerTests/ServicesTests/StatusActivityPubEventItemTests.swift
@@ -1,0 +1,80 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import Vapor
+import Testing
+import Queues
+import Fluent
+
+@Suite("StatusActivityPubEventItem", .serialized)
+struct StatusActivityPubEventItemTests {
+
+    var application: Application!
+
+    init() async throws {
+        self.application = try await ApplicationManager.shared.application()
+    }
+
+    @Test
+    func `New event item should not be suspended by default`() async throws {
+        // Arrange.
+        let user = try await application.createUser(userName: "dafnebenny")
+        let attachment = try await application.createAttachment(user: user)
+        let status = try await application.createStatus(user: user, note: "Note with events", attachmentIds: [attachment.stringId()!], visibility: .public)
+        defer {
+            application.clearFiles(attachments: [attachment])
+        }
+
+        let event = try await application.createStatusActivityPubEvent(statusId: status.requireID(),
+                                                                       userId: user.requireID(),
+                                                                       type: .create,
+                                                                       numberOfSuccessItems: 1)
+
+        // Act.
+        let eventItem = try #require(await StatusActivityPubEventItem.query(on: application.db)
+            .filter(\.$statusActivityPubEvent.$id == event.requireID())
+            .first())
+
+        // Assert.
+        #expect(eventItem.isSuspended == false, "New event item should not be suspended.")
+    }
+
+    @Test
+    func `Suspended function should mark item as suspended without error message`() async throws {
+        // Arrange.
+        let user = try await application.createUser(userName: "jaroslawbenny")
+        let attachment = try await application.createAttachment(user: user)
+        let status = try await application.createStatus(user: user, note: "Note with events", attachmentIds: [attachment.stringId()!], visibility: .public)
+        defer {
+            application.clearFiles(attachments: [attachment])
+        }
+
+        let event = try await application.createStatusActivityPubEvent(statusId: status.requireID(),
+                                                                       userId: user.requireID(),
+                                                                       type: .create,
+                                                                       numberOfSuccessItems: 1)
+
+        let eventItem = try #require(await StatusActivityPubEventItem.query(on: application.db)
+            .filter(\.$statusActivityPubEvent.$id == event.requireID())
+            .first())
+
+        let queueContext = application.getQueueContext(queueName: QueueName(string: "ActivityPubSharedInboxJob"))
+
+        // Act.
+        try await eventItem.suspended(on: queueContext.executionContext)
+
+        // Assert.
+        let eventItemFromDatabase = try #require(await StatusActivityPubEventItem.query(on: application.db)
+            .filter(\.$id == eventItem.requireID())
+            .first())
+
+        #expect(eventItemFromDatabase.isSuccess == nil, "Suspended item should not be marked as failed.")
+        #expect(eventItemFromDatabase.isSuspended == true, "Suspended item should be marked as suspended.")
+        #expect(eventItemFromDatabase.errorMessage == nil, "Suspended item should not contain error message.")
+        #expect(eventItemFromDatabase.endAt != nil, "Suspended item should have end date set.")
+    }
+}

--- a/Tests/VernissageServerTests/ServicesTests/SuspendedServersServiceTests.swift
+++ b/Tests/VernissageServerTests/ServicesTests/SuspendedServersServiceTests.swift
@@ -1,0 +1,139 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import Vapor
+import Testing
+import Queues
+
+@Suite("SuspendedServersService", .serialized)
+struct SuspendedServersServiceTests {
+
+    var application: Application!
+
+    init() async throws {
+        self.application = try await ApplicationManager.shared.application()
+    }
+
+    @Test
+    func `Connection error should create suspended server entry.`() async throws {
+        // Arrange.
+        try await application.clearSuspendedServers()
+        let queueContext = application.getQueueContext(queueName: QueueName(string: "ActivityPubSharedInboxJob"))
+        let suspendedServersService = SuspendedServersService(maxNumberOfErrors: 3)
+
+        // Act.
+        try await suspendedServersService.registerConnectionError(for: "MiXeD.Example.com",
+                                                                  error: URLError(.cannotConnectToHost),
+                                                                  on: queueContext.executionContext)
+
+        // Assert.
+        let suspendedServer = try await application.getSuspendedServer(hostNormalized: "MIXED.EXAMPLE.COM")
+        #expect(suspendedServer != nil, "Suspended server entry should be created.")
+        #expect(suspendedServer?.numberOfErrors == 1, "First connection error should set error counter to 1.")
+        #expect(suspendedServer?.hostNormalized == "MIXED.EXAMPLE.COM", "Host should be normalized to uppercase.")
+    }
+
+    @Test
+    func `Host should be suspended after reaching errors limit.`() async throws {
+        // Arrange.
+        try await application.clearSuspendedServers()
+        let queueContext = application.getQueueContext(queueName: QueueName(string: "ActivityPubSharedInboxJob"))
+        let suspendedServersService = SuspendedServersService(maxNumberOfErrors: 3)
+
+        // Act.
+        try await suspendedServersService.registerConnectionError(for: "down.example.com",
+                                                                  error: URLError(.cannotConnectToHost),
+                                                                  on: queueContext.executionContext)
+        try await suspendedServersService.registerConnectionError(for: "down.example.com",
+                                                                  error: URLError(.cannotConnectToHost),
+                                                                  on: queueContext.executionContext)
+        try await suspendedServersService.registerConnectionError(for: "down.example.com",
+                                                                  error: URLError(.cannotConnectToHost),
+                                                                  on: queueContext.executionContext)
+        let suspendedServers = await suspendedServersService.getSnapshot(on: queueContext.executionContext)
+
+        // Assert.
+        let shouldSend = await suspendedServersService.shouldSend(to: "down.example.com", basedOn: suspendedServers)
+        #expect(shouldSend == false, "Host should be suspended after reaching error limit.")
+    }
+
+    @Test
+    func `After suspension period one failed retry should suspend host again.`() async throws {
+        // Arrange.
+        try await application.clearSuspendedServers()
+        let queueContext = application.getQueueContext(queueName: QueueName(string: "ActivityPubSharedInboxJob"))
+        let suspendedServersService = SuspendedServersService(maxNumberOfErrors: 3)
+
+        try await suspendedServersService.registerConnectionError(for: "retry.example.com",
+                                                                  error: URLError(.cannotConnectToHost),
+                                                                  on: queueContext.executionContext)
+        try await suspendedServersService.registerConnectionError(for: "retry.example.com",
+                                                                  error: URLError(.cannotConnectToHost),
+                                                                  on: queueContext.executionContext)
+        try await suspendedServersService.registerConnectionError(for: "retry.example.com",
+                                                                  error: URLError(.cannotConnectToHost),
+                                                                  on: queueContext.executionContext)
+
+        let suspendedServer = try #require(await application.getSuspendedServer(hostNormalized: "RETRY.EXAMPLE.COM"))
+        suspendedServer.lastErrorDate = Date().addingTimeInterval(-(24 * 60 * 60 + 60))
+        try await suspendedServer.save(on: application.db)
+
+        // Create new service instance to load fresh state from database.
+        let reloadedSuspendedServersService = SuspendedServersService(maxNumberOfErrors: 3)
+        let reloadedSuspendedServers = await reloadedSuspendedServersService.getSnapshot(on: queueContext.executionContext)
+
+        // Act.
+        let shouldSendAfter24Hours = await reloadedSuspendedServersService.shouldSend(to: "retry.example.com",
+                                                                                      basedOn: reloadedSuspendedServers)
+        try await reloadedSuspendedServersService.registerConnectionError(for: "retry.example.com",
+                                                                          error: URLError(.cannotConnectToHost),
+                                                                          on: queueContext.executionContext)
+        let updatedSnapshot = await reloadedSuspendedServersService.getSnapshot(on: queueContext.executionContext)
+        let shouldSendAfterNextError = await reloadedSuspendedServersService.shouldSend(to: "retry.example.com",
+                                                                                        basedOn: updatedSnapshot)
+
+        // Assert.
+        #expect(shouldSendAfter24Hours == true, "Host should be retried after suspension window.")
+        #expect(shouldSendAfterNextError == false, "One failed retry should suspend host again.")
+    }
+
+    @Test
+    func `Successful request should remove host from suspended list.`() async throws {
+        // Arrange.
+        try await application.clearSuspendedServers()
+        let queueContext = application.getQueueContext(queueName: QueueName(string: "ActivityPubSharedInboxJob"))
+        let suspendedServersService = SuspendedServersService(maxNumberOfErrors: 3)
+
+        try await suspendedServersService.registerConnectionError(for: "recovered.example.com",
+                                                                  error: URLError(.cannotConnectToHost),
+                                                                  on: queueContext.executionContext)
+
+        // Act.
+        try await suspendedServersService.registerSuccess(for: "recovered.example.com", on: queueContext.executionContext)
+
+        // Assert.
+        let suspendedServer = try await application.getSuspendedServer(hostNormalized: "RECOVERED.EXAMPLE.COM")
+        #expect(suspendedServer == nil, "Suspended server should be removed after successful request.")
+    }
+
+    @Test
+    func `Non connection error should not create suspended server entry.`() async throws {
+        // Arrange.
+        try await application.clearSuspendedServers()
+        let queueContext = application.getQueueContext(queueName: QueueName(string: "ActivityPubSharedInboxJob"))
+        let suspendedServersService = SuspendedServersService(maxNumberOfErrors: 3)
+
+        // Act.
+        try await suspendedServersService.registerConnectionError(for: "http-error.example.com",
+                                                                  error: Abort(.badRequest),
+                                                                  on: queueContext.executionContext)
+
+        // Assert.
+        let suspendedServer = try await application.getSuspendedServer(hostNormalized: "HTTP-ERROR.EXAMPLE.COM")
+        #expect(suspendedServer == nil, "Only connection errors should be tracked as suspended server errors.")
+    }
+}


### PR DESCRIPTION
Since now, we send requests to all servers from users’ sharedInbox/userInbox, even if the server is not operational for an extended period. This PR introduces a mechanism that detects when a server is not running and, if several issues are encountered, suspends sending requests to that server for 24 hours. After that, we attempt to send a request again, and if it still fails, we suspend sending for another 24 hours.