### PR TITLE
Add to trending readble hashtags

### DIFF
--- a/Sources/VernissageServer/Services/TrendingService.swift
+++ b/Sources/VernissageServer/Services/TrendingService.swift
@@ -368,7 +368,17 @@ final class TrendingService: TrendingServiceType {
         let trendingHashtag = try await sql.raw("""
             SELECT
                 \(ident: "st").\(ident: "hashtagNormalized") AS \(ident: "hashtagNormalized"),
-                (SELECT \(ident: "hashtag") FROM \(ident: StatusHashtag.schema) WHERE \(ident: "hashtagNormalized") = \(ident: "st").\(ident: "hashtagNormalized") LIMIT 1) AS \(ident: "hashtag"),
+                (
+                    SELECT \(ident: "sh").\(ident: "hashtag")
+                    FROM \(ident: StatusHashtag.schema) \(ident: "sh")
+                    WHERE \(ident: "sh").\(ident: "hashtagNormalized") = \(ident: "st").\(ident: "hashtagNormalized")
+                    GROUP BY \(ident: "sh").\(ident: "hashtag")
+                    ORDER BY
+                        (lower(\(ident: "sh").\(ident: "hashtag")) <> \(ident: "sh").\(ident: "hashtag") AND upper(\(ident: "sh").\(ident: "hashtag")) <> \(ident: "sh").\(ident: "hashtag")) DESC,
+                        COUNT(*) DESC,
+                        \(ident: "sh").\(ident: "hashtag") ASC
+                    LIMIT 1
+                ) AS \(ident: "hashtag"),
                 COUNT(\(ident: "st").\(ident: "hashtagNormalized")) AS \(ident: "amount")
             FROM \(ident: Status.schema) \(ident: "s")
                 INNER JOIN \(ident: StatusHashtag.schema) \(ident: "st") ON \(ident: "st").\(ident: "statusId") = \(ident: "s").\(ident: "id")

--- a/Tests/VernissageServerTests/ServicesTests/TrendingServiceTests.swift
+++ b/Tests/VernissageServerTests/ServicesTests/TrendingServiceTests.swift
@@ -77,4 +77,45 @@ struct TrendingServiceTests {
         let trendingHashtags = try await application.getAllTrendingHashtags()
         #expect(trendingHashtags.first(where: { $0.hashtag == "black"}) != nil, "Hashtag should be marked as trenidng status.")
     }
+    
+    @Test
+    func `Hashtag should prefer readable mixed case representation when available.`() async throws {
+        // Arrange.
+        let user1 = try await application.createUser(userName: "hashtagcaseauthor")
+        let user2 = try await application.createUser(userName: "hashtagcaseliker")
+        
+        let (lowercaseStatuses, lowercaseAttachments) = try await application.createStatuses(
+            user: user1,
+            notePrefix: "Lowercase hashtag #streetphoto",
+            amount: 3
+        )
+        
+        let (mixedCaseStatuses, mixedCaseAttachments) = try await application.createStatuses(
+            user: user1,
+            notePrefix: "Mixed case hashtag #StreetPhoto",
+            amount: 1
+        )
+        
+        defer {
+            application.clearFiles(attachments: lowercaseAttachments + mixedCaseAttachments)
+        }
+        
+        for status in lowercaseStatuses + mixedCaseStatuses {
+            try await application.favouriteStatus(user: user2, status: status)
+        }
+        
+        // Act.
+        let queueContext = application.getQueueContext(queueName: QueueName(string: "TrendingJob"))
+        await application.services.trendingService.calculateTrendingHashtags(period: .daily, on: queueContext)
+        
+        // Assert.
+        let trendingHashtags = try await application.getAllTrendingHashtags()
+        let streetPhotoTrending = trendingHashtags.first(where: {
+            $0.trendingPeriod == .daily && $0.hashtagNormalized == "STREETPHOTO"
+        })
+        
+        #expect(streetPhotoTrending != nil, "StreetPhoto hashtag should be calculated as trending.")
+        #expect(streetPhotoTrending?.hashtag == "StreetPhoto", "Trending hashtag should prefer mixed case representation.")
+        #expect(streetPhotoTrending?.amount == 4, "Trending hashtag amount should count all case variants.")
+    }
 }


### PR DESCRIPTION
Now we will sort hashtags in specific order:

1. **(lower(sh."hashtag") <> sh."hashtag" AND upper(sh."hashtag") <> sh."hashtag") DESC**
This returns true only for mixed strings (StreetPhoto):
  - lower(...) <> ... means: the tag is not quite small
  - upper(...) <> ... means: the tag is not quite LARGE
Total: it is neither all-lower nor all-upper, so it is "mixed case".
DESC makes true go before false.

2. **COUNT(*) DESC**
Count of occurrences. Descending sorting takes the most frequently used variant within the same class from step 1.

3. **sh."hashtag" ASC**
If there is still a tie (e.g., two variants have the same COUNT(*)), the selection is deterministic alphabetically. This eliminates the randomness of the result.