### PR TITLE
Change size of state column for OAuth client requests

### DIFF
--- a/Sources/VernissageServer/Application+Migrations.swift
+++ b/Sources/VernissageServer/Application+Migrations.swift
@@ -200,5 +200,6 @@ extension Application {
         self.migrations.add(Report.AddActivityPubId())
         self.migrations.add(SuspendedServer.CreateSuspendedServers())
         self.migrations.add(StatusActivityPubEventItem.AddIsSuspendedField())
+        self.migrations.add(OAuthClientRequest.ChangeStateLength())
     }
 }

--- a/Sources/VernissageServer/Constants.swift
+++ b/Sources/VernissageServer/Constants.swift
@@ -9,7 +9,7 @@ import Vapor
 /// Basic constants used in the system.
 public final class Constants {
     public static let name = "Vernissage"
-    public static let version = "1.34.0-buildx"
+    public static let version = "1.35.0-buildx"
     public static let applicationName = "\(Constants.name) \(Constants.version)"
     public static let userAgent = "(\(Constants.name)/\(Constants.version))"
     public static let requestMetadata = "Request body"

--- a/Sources/VernissageServer/Migrations/CreateOAuthClientRequests.swift
+++ b/Sources/VernissageServer/Migrations/CreateOAuthClientRequests.swift
@@ -7,6 +7,7 @@
 import Vapor
 import Fluent
 import SQLKit
+import SQLiteKit
 
 extension OAuthClientRequest {
     struct CreateOAuthClientRequests: AsyncMigration {
@@ -63,6 +64,32 @@ extension OAuthClientRequest {
                     .on(OAuthClientRequest.schema)
                     .run()
             }
+        }
+    }
+    
+    struct ChangeStateLength: AsyncMigration {
+        func prepare(on database: Database) async throws {
+            // SQLite only supports adding columns in ALTER TABLE statements.
+            if let _ = database as? SQLiteDatabase {
+                return
+            }
+            
+            try await database
+                .schema(OAuthClientRequest.schema)
+                .updateField("state", .varchar(1000))
+                .update()
+        }
+        
+        func revert(on database: Database) async throws {
+            // SQLite only supports adding columns in ALTER TABLE statements.
+            if let _ = database as? SQLiteDatabase {
+                return
+            }
+
+            try await database
+                .schema(OAuthClientRequest.schema)
+                .updateField("state", .varchar(100))
+                .update()
         }
     }
 }


### PR DESCRIPTION
State column can be longer than 100 characters in some cases (now it's 1000 characters which should be enough).