### PR TITLE
#546 Add create/announce support for user inbox (with visibility validations)

### DIFF
--- a/Sources/VernissageServer/Controllers/ActivityPubActorsController.swift
+++ b/Sources/VernissageServer/Controllers/ActivityPubActorsController.swift
@@ -835,7 +835,7 @@ struct ActivityPubActorsController {
             throw EntityNotFoundError.statusNotFound
         }
         
-        guard status.visibility != .mentioned else {
+        guard [.public, .quietPublic].contains(status.visibility) else {
             throw EntityForbiddenError.statusForbidden
         }
         

--- a/Sources/VernissageServer/Controllers/StatusesController.swift
+++ b/Sources/VernissageServer/Controllers/StatusesController.swift
@@ -634,8 +634,6 @@ struct StatusesController {
     /// - Throws: `EntityForbiddenError.statusForbidden` if access to status is forbidden.
     @Sendable
     func read(request: Request) async throws -> StatusDto {
-        let authorizationPayloadId = request.userId
-
         guard let statusIdString = request.parameters.get("id", as: String.self) else {
             throw StatusError.incorrectStatusId
         }
@@ -644,7 +642,7 @@ struct StatusesController {
             throw StatusError.incorrectStatusId
         }
         
-        if let authorizationPayloadId {
+        if let authorizationPayloadId = request.userId {
             let status = try await Status.query(on: request.db)
                 .filter(\.$id == statusId)
                 .with(\.$attachments) { attachment in
@@ -2592,6 +2590,10 @@ struct StatusesController {
         let statusFromDatabaseBeforeFeature = try await statusesService.get(id: statusId, on: request.db)
         guard let statusFromDatabaseBeforeFeature else {
             throw EntityNotFoundError.statusNotFound
+        }
+
+        guard [.public, .quietPublic].contains(statusFromDatabaseBeforeFeature.visibility) else {
+            throw EntityForbiddenError.statusForbidden
         }
         
         // We have to verify if user have access to the status (it's not only for mentioned).

--- a/Sources/VernissageServer/QueueJobs/ActivityPubUserInboxJob.swift
+++ b/Sources/VernissageServer/QueueJobs/ActivityPubUserInboxJob.swift
@@ -26,6 +26,9 @@ struct ActivityPubUserInboxJob: AsyncJob {
         switch payload.activity.type {
         case .delete:
             try await activityPubService.delete(activityPubRequest: payload, on: executionContext)
+        case .create:
+            try await activityPubSignatureService.validateSignature(activityPubRequest: payload, on: executionContext)
+            try await activityPubService.create(activityPubRequest: payload, on: executionContext)
         case .update:
             try await activityPubSignatureService.validateSignature(activityPubRequest: payload, on: executionContext)
             try await activityPubService.update(activityPubRequest: payload, on: executionContext)
@@ -47,6 +50,9 @@ struct ActivityPubUserInboxJob: AsyncJob {
                 try await activityPubSignatureService.validateSignature(activityPubRequest: payload, on: executionContext)
                 try await activityPubService.undo(activityPubRequest: payload, on: executionContext)
             }
+        case .announce:
+            try await activityPubSignatureService.validateSignature(activityPubRequest: payload, on: executionContext)
+            try await activityPubService.announce(activityPubRequest: payload, on: executionContext)
         case .like:
             try await activityPubSignatureService.validateSignature(activityPubRequest: payload, on: executionContext)
             try await activityPubService.like(activityPubRequest: payload, on: executionContext)

--- a/Sources/VernissageServer/Services/ActivityPubService.swift
+++ b/Sources/VernissageServer/Services/ActivityPubService.swift
@@ -389,6 +389,15 @@ final class ActivityPubService: ActivityPubServiceType {
                     context.logger.warning("Cannot find any ActivityPub actor profile id (activity: \(activity.id)).")
                     continue
                 }
+
+                // Determine whether the incoming status is public, quiet public, followers-only, or mentioned.
+                let statusVisibility = self.resolveStatusVisibility(noteDto: noteDto, activity: activity)
+
+                // Detect the local user targeted by this inbox endpoint when the activity came via /actors/:name/inbox.
+                let userInboxRecipientId = try await self.userInboxRecipientId(for: activityPubRequest.httpPath, on: context)
+
+                // Collect all local users explicitly addressed in to/cc so we can validate and route mentioned/direct statuses.
+                let localRecipientUserIds = try await self.localRecipientUserIds(noteDto: noteDto, activity: activity, on: context)
                 
                 // Validations for regular status (with images).
                 if noteDto.isComment() == false {
@@ -402,7 +411,23 @@ final class ActivityPubService: ActivityPubServiceType {
                     // Prevent creating new statuses when author is not followed by anyone in the instance.
                     let isRemoteUserFollowedByAnyone = try await self.isRemoteUserFollowedByAnyone(activityPubProfile: activityPubProfile, on: context)
                     if isRemoteUserFollowedByAnyone == false {
-                        context.logger.warning("Author of the status is not followed by anyone on the instance (activity: \(activity.id)).")
+                        if statusVisibility == .mentioned, localRecipientUserIds.isEmpty == false {
+                            context.logger.info("Processing mentioned status from unfollowed actor because local recipients exist (activity: \(activity.id)).")
+                        } else {
+                            context.logger.warning("Author of the status is not followed by anyone on the instance (activity: \(activity.id)).")
+                            continue
+                        }
+                    }
+                }
+
+                if let userInboxRecipientId {
+                    let shouldProcessForUserInbox = try await self.shouldProcessForUserInbox(recipientUserId: userInboxRecipientId,
+                                                                                             sourceActorActivityPubProfile: activityPubProfile,
+                                                                                             statusVisibility: statusVisibility,
+                                                                                             localRecipientUserIds: localRecipientUserIds,
+                                                                                             on: context)
+                    if shouldProcessForUserInbox == false {
+                        context.logger.info("Skipping create activity for user inbox recipient due to visibility/relationship rules (activity: \(activity.id), userId: \(userInboxRecipientId)).")
                         continue
                     }
                 }
@@ -453,15 +478,27 @@ final class ActivityPubService: ActivityPubServiceType {
                 
                 do {
                     // Create status into database.
-                    let statusFromDatabase = try await statusesService.create(basedOn: noteDto, userId: user.requireID(), on: context)
+                    let statusFromDatabase = try await statusesService.create(basedOn: noteDto,
+                                                                              userId: user.requireID(),
+                                                                              visibility: statusVisibility,
+                                                                              on: context)
 
                     // Recalculate numer of user statuses.
                     try await statusesService.updateStatusCount(for: user.requireID(), on: context.application.db)
                     
                     // Add new status to user's timelines (except comments).
                     if statusFromDatabase.$replyToStatus.id == nil {
-                        try await statusesService.createOnLocalTimeline(followersOf: user.requireID(), status: statusFromDatabase, on: context)
-                        try await statusesService.createOnLocalTimelineForHashtagsFollowers(status: statusFromDatabase, on: context)
+                        switch statusFromDatabase.visibility {
+                        case .public:
+                            try await statusesService.createOnLocalTimeline(followersOf: user.requireID(), status: statusFromDatabase, on: context)
+                            try await statusesService.createOnLocalTimelineForHashtagsFollowers(status: statusFromDatabase, on: context)
+                        case .quietPublic, .followers:
+                            try await statusesService.createOnLocalTimeline(followersOf: user.requireID(), status: statusFromDatabase, on: context)
+                        case .mentioned:
+                            try await statusesService.createOnLocalTimeline(mentionedUsers: localRecipientUserIds,
+                                                                            status: statusFromDatabase,
+                                                                            on: context)
+                        }
                     }
                 } catch StatusError.cannotAddCommentWithoutCommentedStatus {
                     // Consume this kind of error (it’s not a real error - we cannot create comment to not exists status).
@@ -856,20 +893,33 @@ final class ActivityPubService: ActivityPubServiceType {
                 context.logger.warning("Boosted status '\(object.id)' doesn't contains any images (activity: \(activity.id)).")
                 continue
             }
+
+            let remoteUserId = try remoteUser.requireID()
+            let mainStatusId = try mainStatusFromDatabase.requireID()
+
+            let existingReblog = try await Status.query(on: context.db)
+                .filter(\.$user.$id == remoteUserId)
+                .filter(\.$reblog.$id == mainStatusId)
+                .first()
+
+            if existingReblog != nil {
+                context.logger.info("Skipping duplicate announce for status '\(object.id)' by actor '\(actorActivityPubId)' (activity: \(activity.id)).")
+                continue
+            }
                         
             // Create reblog status.
             let statusId = context.application.services.snowflakeService.generate()
-            let reblogStatus = try Status(id: statusId,
-                                          isLocal: false,
-                                          userId: remoteUser.requireID(),
-                                          note: nil,
-                                          baseAddress: baseAddress,
-                                          userName: remoteUser.userName,
-                                          application: nil,
-                                          categoryId: nil,
-                                          visibility: .public,
-                                          reblogId: mainStatusFromDatabase.requireID(),
-                                          publishedAt: Date())
+            let reblogStatus = Status(id: statusId,
+                                      isLocal: false,
+                                      userId: remoteUserId,
+                                      note: nil,
+                                      baseAddress: baseAddress,
+                                      userName: remoteUser.userName,
+                                      application: nil,
+                                      categoryId: nil,
+                                      visibility: .public,
+                                      reblogId: mainStatusId,
+                                      publishedAt: Date())
             
             try await reblogStatus.create(on: context.db)
             try await statusesService.updateReblogsCount(for: mainStatusFromDatabase.requireID(), on: context.db)
@@ -879,15 +929,15 @@ final class ActivityPubService: ActivityPubServiceType {
                 let notificationsService = context.application.services.notificationsService
                 try await notificationsService.create(type: .reblog,
                                                       to: mainStatusFromDatabase.user,
-                                                      by: remoteUser.requireID(),
-                                                      statusId: mainStatusFromDatabase.requireID(),
+                                                      by: remoteUserId,
+                                                      statusId: mainStatusId,
                                                       mainStatusId: nil,
                                                       on: context)
             }
             
             // Add new reblog status to user's timelines.
             context.logger.info("Connecting status '\(reblogStatus.stringId() ?? "")' to followers of '\(remoteUser.stringId() ?? "")'.")
-            try await statusesService.createOnLocalTimeline(followersOf: remoteUser.requireID(), status: reblogStatus, on: context)
+            try await statusesService.createOnLocalTimeline(followersOf: remoteUserId, status: reblogStatus, on: context)
 
             // Status should be processed by following hashtags mechanism only when it was created.
             if let downloadedStatusCreatedAt = downloadedStatus.createdAt,
@@ -2094,7 +2144,10 @@ final class ActivityPubService: ActivityPubServiceType {
         
         // Create status in database.
         context.logger.info("Creating status in local database: '\(activityPubId)'.")
-        let status = try await statusesService.create(basedOn: noteDto, userId: remoteUser.requireID(), on: context)
+        let status = try await statusesService.create(basedOn: noteDto,
+                                                      userId: remoteUser.requireID(),
+                                                      visibility: .public,
+                                                      on: context)
         
         // Recalculate numer of user statuses.
         try await statusesService.updateStatusCount(for: remoteUser.requireID(), on: context.db)
@@ -2161,6 +2214,108 @@ final class ActivityPubService: ActivityPubServiceType {
             .count()
 
         return followers > 0
+    }
+
+    private func resolveStatusVisibility(noteDto: NoteDto, activity: ActivityDto) -> StatusVisibility {
+        let publicAddress = "https://www.w3.org/ns/activitystreams#Public"
+        let toActorIds = noteDto.to?.actorIds() ?? activity.to?.actorIds() ?? []
+        let ccActorIds = noteDto.cc?.actorIds() ?? activity.cc?.actorIds() ?? []
+        let allActorIds = toActorIds + ccActorIds
+
+        // Public in "to" means fully public post visible to everyone.
+        if toActorIds.contains(publicAddress) {
+            return .public
+        }
+
+        // Public in "cc" means unlisted/quiet public post shared without direct public addressing.
+        if ccActorIds.contains(publicAddress) {
+            return .quietPublic
+        }
+
+        // Addressing followers collection indicates followers-only visibility.
+        if allActorIds.contains(where: { $0.hasSuffix("/followers") }) {
+            return .followers
+        }
+
+        // If none of the above matched, treat it as direct/mentioned visibility.
+        return .mentioned
+    }
+
+    private func userInboxRecipientId(for requestPath: ActivityPubRequestPath, on context: ExecutionContext) async throws -> Int64? {
+        let usersService = context.services.usersService
+
+        switch requestPath {
+        case .userInbox(let userName):
+            return try await usersService.get(userName: userName, on: context.db)?.id
+        case .applicationUserInbox:
+            return try await usersService.getDefaultSystemUser(on: context.db)?.id
+        default:
+            return nil
+        }
+    }
+
+    private func localRecipientUserIds(noteDto: NoteDto, activity: ActivityDto, on context: ExecutionContext) async throws -> [Int64] {
+        let publicAddress = "https://www.w3.org/ns/activitystreams#Public"
+        let usersService = context.services.usersService
+        let noteRecipientIds = (noteDto.to?.actorIds() ?? []) + (noteDto.cc?.actorIds() ?? [])
+        let activityRecipientIds = (activity.to?.actorIds() ?? []) + (activity.cc?.actorIds() ?? [])
+        let recipientIds = noteRecipientIds.isEmpty ? activityRecipientIds : noteRecipientIds
+
+        var userIds: Set<Int64> = []
+        for recipientId in recipientIds {
+            // Skip the global Public address because it is not a concrete local recipient.
+            if recipientId == publicAddress {
+                continue
+            }
+
+            let actorId = recipientId.hasSuffix("/followers")
+                ? String(recipientId.dropLast("/followers".count))
+                : recipientId
+
+            guard let user = try await usersService.get(activityPubProfile: actorId, on: context.db),
+                  user.isLocal else {
+                continue
+            }
+
+            userIds.insert(try user.requireID())
+        }
+
+        return Array(userIds)
+    }
+
+    private func shouldProcessForUserInbox(recipientUserId: Int64,
+                                           sourceActorActivityPubProfile: String,
+                                           statusVisibility: StatusVisibility,
+                                           localRecipientUserIds: [Int64],
+                                           on context: ExecutionContext) async throws -> Bool {
+        // Always process when the inbox owner is explicitly addressed in to/cc.
+        if localRecipientUserIds.contains(recipientUserId) {
+            return true
+        }
+
+        // Reject direct/mentioned activities for this inbox when recipient is not explicitly addressed.
+        if statusVisibility == .mentioned {
+            return false
+        }
+
+        // Public activities are allowed for user inbox processing even without explicit mention.
+        if statusVisibility == .public {
+            return true
+        }
+
+        let usersService = context.services.usersService
+        guard let sourceUser = try await usersService.get(activityPubProfile: sourceActorActivityPubProfile, on: context.db) else {
+            return false
+        }
+
+        let sourceUserId = try sourceUser.requireID()
+        let follow = try await Follow.query(on: context.db)
+            .filter(\.$source.$id == recipientUserId)
+            .filter(\.$target.$id == sourceUserId)
+            .filter(\.$approved == true)
+            .first()
+
+        return follow != nil
     }
 
     private func refreshRemoteUser(activityPubRequest: ActivityPubRequestDto, action: String, on context: ExecutionContext) async throws {

--- a/Sources/VernissageServer/Services/CollectionsService.swift
+++ b/Sources/VernissageServer/Services/CollectionsService.swift
@@ -113,7 +113,10 @@ final class CollectionsService: CollectionsServiceType {
                 }
 
                 // Try to create status based on data from the collection.
-                status = try? await statusesService.create(basedOn: noteDto, userId: userId, on: context)
+                status = try? await statusesService.create(basedOn: noteDto,
+                                                           userId: userId,
+                                                           visibility: .public,
+                                                           on: context)
             }
 
             // When we don't have status in collection od creating failed then try to download status from remote server.
@@ -284,4 +287,5 @@ final class CollectionsService: CollectionsServiceType {
 
         return URL(string: value, relativeTo: baseUrl)?.absoluteURL
     }
+
 }

--- a/Sources/VernissageServer/Services/StatusesService.swift
+++ b/Sources/VernissageServer/Services/StatusesService.swift
@@ -211,10 +211,11 @@ protocol StatusesServiceType: Sendable {
     /// - Parameters:
     ///   - noteDto: The NoteDto containing status information.
     ///   - userId: The user identifier creating the status.
+    ///   - visibility: Explicit status visibility parsed from ActivityPub addressing.
     ///   - context: The execution context for database and services.
     /// - Returns: The created Status.
     /// - Throws: An error if creation fails.
-    func create(basedOn noteDto: NoteDto, userId: Int64, on context: ExecutionContext) async throws -> Status
+    func create(basedOn noteDto: NoteDto, userId: Int64, visibility: StatusVisibility, on context: ExecutionContext) async throws -> Status
     
     /// Creates a new status based on a StatusRequestDto.
     ///
@@ -262,6 +263,15 @@ protocol StatusesServiceType: Sendable {
     ///   - context: The execution context for database and services.
     /// - Throws: An error if the operation fails.
     func createOnLocalTimelineForHashtagsFollowers(status: Status, on context: ExecutionContext) async throws
+    
+    /// Creates status entries on the local timeline for explicitly mentioned local users.
+    ///
+    /// - Parameters:
+    ///   - userIds: Local user identifiers that should receive the status.
+    ///   - status: The status to propagate.
+    ///   - context: The execution context for database and services.
+    /// - Throws: An error if the operation fails.
+    func createOnLocalTimeline(mentionedUsers userIds: [Int64], status: Status, on context: ExecutionContext) async throws
     
     /// Converts a status to a Data Transfer Object (DTO).
     ///
@@ -979,7 +989,7 @@ final class StatusesService: StatusesServiceType {
         }
     }
 
-    func create(basedOn noteDto: NoteDto, userId: Int64, on context: ExecutionContext) async throws -> Status {
+    func create(basedOn noteDto: NoteDto, userId: Int64, visibility: StatusVisibility, on context: ExecutionContext) async throws -> Status {
         
         // First we need to check if status with same activityPubId already exists in the database.
         let statusFromDatabase = try await self.get(activityPubId: noteDto.id, on: context.db)
@@ -1030,7 +1040,7 @@ final class StatusesService: StatusesServiceType {
                             activityPubUrl: noteDto.url,
                             application: nil,
                             categoryId: category?.id,
-                            visibility: replyToStatus?.visibility ?? .public,
+                            visibility: visibility,
                             sensitive: noteDto.sensitive ?? false,
                             contentWarning: noteDto.summary,
                             replyToStatusId: replyToStatus?.id,
@@ -1717,6 +1727,30 @@ final class StatusesService: StatusesServiceType {
         }
     }
     
+    func createOnLocalTimeline(mentionedUsers userIds: [Int64], status: Status, on context: ExecutionContext) async throws {
+        let statusId = try status.requireID()
+        let uniqueUserIds = Set(userIds)
+
+        for userId in uniqueUserIds where userId != status.$user.id {
+            let alreadyExists = try await UserStatus.query(on: context.db)
+                .filter(\.$status.$id == statusId)
+                .filter(\.$user.$id == userId)
+                .first() != nil
+
+            if alreadyExists {
+                continue
+            }
+
+            let newUserStatusId = context.services.snowflakeService.generate()
+            let userStatus = UserStatus(id: newUserStatusId,
+                                        type: .mention,
+                                        userId: userId,
+                                        statusId: statusId)
+
+            try await userStatus.create(on: context.db)
+        }
+    }
+    
     public func reblogged(statusId: Int64, linkableParams: LinkableParams, on context: ExecutionContext) async throws -> LinkableResult<User> {
         var queryBuilder = Status.query(on: context.db)
             .with(\.$user) { user in
@@ -2332,7 +2366,7 @@ final class StatusesService: StatusesServiceType {
     
     func can(view status: Status, userId: Int64?, on context: ExecutionContext) async throws -> Bool {
         // These statuses can see all of the people over the internet.
-        if [.public, .followers, .quietPublic].contains(status.visibility) {
+        if [.public, .quietPublic].contains(status.visibility) {
             return true
         }
         
@@ -2684,7 +2718,7 @@ final class StatusesService: StatusesServiceType {
         var query = Status.query(on: context.db)
             .group(.or) { group in
                 group
-                    .filter(\.$visibility ~~ [.public])
+                    .filter(\.$visibility ~~ [.public, .quietPublic])
                     .filter(\.$user.$id == userId)
             }
             .sort(\.$createdAt, .descending)
@@ -2732,7 +2766,7 @@ final class StatusesService: StatusesServiceType {
     
     func statuses(linkableParams: LinkableParams, on context: ExecutionContext) async throws -> LinkableResult<Status> {
         var query = Status.query(on: context.db)
-            .filter(\.$visibility ~~ [.public])
+            .filter(\.$visibility ~~ [.public, .quietPublic])
             .sort(\.$createdAt, .descending)
             .with(\.$attachments) { attachment in
                 attachment.with(\.$originalFile)

--- a/Sources/VernissageServer/Services/TrendingService.swift
+++ b/Sources/VernissageServer/Services/TrendingService.swift
@@ -333,6 +333,7 @@ final class TrendingService: TrendingServiceType {
                 \(ident: "sf").\(ident: "createdAt") > \(bind: past)
                 AND \(ident: "s").\(ident: "reblogId") IS NULL
                 AND \(ident: "s").\(ident: "replyToStatusId") IS NULL
+                AND \(ident: "s").\(ident: "visibility") IN (\(bind: StatusVisibility.public.rawValue), \(bind: StatusVisibility.quietPublic.rawValue))
             GROUP BY \(ident: "sf").\(ident: "statusId"), \(ident: "s").\(ident: "createdAt")
             ORDER BY COUNT(\(ident: "sf").\(ident: "statusId")), \(ident: "s").\(ident: "createdAt") DESC
             LIMIT 1000

--- a/Tests/VernissageServerTests/AcceptanceTests/ActivityPubActorsController/ActivityPubActorsStatusActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/ActivityPubActorsController/ActivityPubActorsStatusActionTests.swift
@@ -185,6 +185,105 @@ extension ControllersTests {
                 NoteTagDto(type: "Category", name: "Street", href: "http://localhost:8080/categories/Street")
             ]), "Property 'tag' should contain category.")
         }
+
+        @Test
+        func `Quiet public status should be returned for all supported urls`() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "quietactivitypub")
+            let attachment = try await application.createAttachment(user: user)
+            defer {
+                application.clearFiles(attachments: [attachment])
+            }
+
+            let status = try await application.createStatus(user: user,
+                                                            note: "QUIET ACTIVITY PUB",
+                                                            attachmentIds: [attachment.stringId()!],
+                                                            visibility: .quietPublic)
+
+            // Act.
+            let actorNoteDto = try await application.getResponse(
+                to: "/actors/\(user.userName)/statuses/\(status.requireID())",
+                version: .none,
+                method: .GET,
+                decodeTo: NoteDto.self
+            )
+            let shortNoteDto = try await application.getResponse(
+                to: "/@\(user.userName)/\(status.requireID())",
+                version: .none,
+                method: .GET,
+                decodeTo: NoteDto.self
+            )
+            let statusesNoteDto = try await application.getResponse(
+                to: "/statuses/\(status.requireID())",
+                version: .none,
+                method: .GET,
+                decodeTo: NoteDto.self
+            )
+
+            // Assert.
+            #expect(actorNoteDto.id == "http://localhost:8080/actors/\(user.userName)/statuses/\(status.stringId() ?? "")",
+                    "Status should be returned for '/actors/:name/statuses/:id'.")
+            #expect(shortNoteDto.id == "http://localhost:8080/actors/\(user.userName)/statuses/\(status.stringId() ?? "")",
+                    "Status should be returned for '/@:name/:id'.")
+            #expect(statusesNoteDto.id == "http://localhost:8080/actors/\(user.userName)/statuses/\(status.stringId() ?? "")",
+                    "Status should be returned for '/statuses/:id'.")
+        }
+
+        @Test
+        func `Followers and mentioned statuses should be forbidden for all supported urls`() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "privateactivitypub")
+            let followersAttachment = try await application.createAttachment(user: user)
+            let mentionedAttachment = try await application.createAttachment(user: user)
+            defer {
+                application.clearFiles(attachments: [followersAttachment, mentionedAttachment])
+            }
+
+            let followersStatus = try await application.createStatus(user: user,
+                                                                     note: "FOLLOWERS AP HIDDEN",
+                                                                     attachmentIds: [followersAttachment.stringId()!],
+                                                                     visibility: .public)
+            try await application.changeStatusVisibility(statusId: followersStatus.requireID(), visibility: .followers)
+            let mentionedStatus = try await application.createStatus(user: user,
+                                                                     note: "MENTIONED AP HIDDEN",
+                                                                     attachmentIds: [mentionedAttachment.stringId()!],
+                                                                     visibility: .public)
+            try await application.changeStatusVisibility(statusId: mentionedStatus.requireID(), visibility: .mentioned)
+
+            let followersStatusId = try followersStatus.requireID()
+            let mentionedStatusId = try mentionedStatus.requireID()
+
+            let followersPaths = [
+                "/actors/\(user.userName)/statuses/\(followersStatusId)",
+                "/@\(user.userName)/\(followersStatusId)",
+                "/statuses/\(followersStatusId)"
+            ]
+
+            for path in followersPaths {
+                let errorResponse = try await application.getErrorResponse(
+                    to: path,
+                    version: .none,
+                    method: .GET
+                )
+                #expect(errorResponse.status == HTTPResponseStatus.forbidden,
+                        "Followers status should be forbidden for '\(path)'.")
+            }
+
+            let mentionedPaths = [
+                "/actors/\(user.userName)/statuses/\(mentionedStatusId)",
+                "/@\(user.userName)/\(mentionedStatusId)",
+                "/statuses/\(mentionedStatusId)"
+            ]
+
+            for path in mentionedPaths {
+                let errorResponse = try await application.getErrorResponse(
+                    to: path,
+                    version: .none,
+                    method: .GET
+                )
+                #expect(errorResponse.status == HTTPResponseStatus.forbidden,
+                        "Mentioned status should be forbidden for '\(path)'.")
+            }
+        }
     }
 }
-

--- a/Tests/VernissageServerTests/AcceptanceTests/StatusesController/StatusesFeatureActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/StatusesController/StatusesFeatureActionTests.swift
@@ -150,6 +150,35 @@ extension ControllersTests {
             // Assert.
             #expect(errorResponse.status == HTTPResponseStatus.forbidden, "Response http status code should be forbidden (403).")
         }
+
+        @Test
+        func `Forbidden should be returned for status with followers visibility`() async throws {
+            
+            // Arrange.
+            let moderator = try await application.createUser(userName: "followersfeaturemod")
+            try await application.attach(user: moderator, role: Role.moderator)
+            
+            let attachment = try await application.createAttachment(user: moderator)
+            let status = try await application.createStatus(user: moderator,
+                                                            note: "Followers only status",
+                                                            attachmentIds: [attachment.stringId()!],
+                                                            visibility: .followers)
+            defer {
+                application.clearFiles(attachments: [attachment])
+            }
+            
+            // Act.
+            let errorResponse = try await application.getErrorResponse(
+                as: .user(userName: "followersfeaturemod", password: "p@ssword"),
+                to: "/statuses/\(status.requireID())/feature",
+                method: .POST
+            )
+            
+            // Assert.
+            #expect(errorResponse.status == HTTPResponseStatus.forbidden, "Response http status code should be forbidden (403).")
+            #expect(errorResponse.error.code == EntityForbiddenError.statusForbidden.code, "Error code should be equal statusForbidden.")
+            #expect(errorResponse.error.reason == EntityForbiddenError.statusForbidden.reason, "Error reason should be equal status forbidden message.")
+        }
         
         @Test
         func `Not found should be returned if status not exists`() async throws {

--- a/Tests/VernissageServerTests/AcceptanceTests/StatusesController/StatusesListActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/StatusesController/StatusesListActionTests.swift
@@ -57,35 +57,125 @@ extension ControllersTests {
         }
         
         @Test
-        func `Other user private statuses should not be returned`() async throws {
+        func `Public statuses and all own statuses should be returned for authorized user`() async throws {
             
             // Arrange.
-            let user1 = try await application.createUser(userName: "evelyncyan")
-            let attachment1 = try await application.createAttachment(user: user1)
+            let user = try await application.createUser(userName: "visibilitylistowner")
+            let otherUser = try await application.createUser(userName: "visibilitylistother")
+
+            let publicAttachment = try await application.createAttachment(user: user)
+            let quietAttachment = try await application.createAttachment(user: user)
+            let followersAttachment = try await application.createAttachment(user: user)
+            let mentionedAttachment = try await application.createAttachment(user: user)
+            let otherFollowersAttachment = try await application.createAttachment(user: otherUser)
+            let otherMentionedAttachment = try await application.createAttachment(user: otherUser)
             defer {
-                application.clearFiles(attachments: [attachment1])
+                application.clearFiles(attachments: [publicAttachment,
+                                                     quietAttachment,
+                                                     followersAttachment,
+                                                     mentionedAttachment,
+                                                     otherFollowersAttachment,
+                                                     otherMentionedAttachment])
             }
-            
-            let user2 = try await application.createUser(userName: "fredcyan")
-            let attachment2 = try await application.createAttachment(user: user2)
-            defer {
-                application.clearFiles(attachments: [attachment2])
-            }
-            
-            _ = try await application.createStatus(user: user1, note: "PRIVATE 1", attachmentIds: [attachment1.stringId()!], visibility: .followers)
-            _ = try await application.createStatus(user: user2, note: "PRIVATE 2", attachmentIds: [attachment2.stringId()!], visibility: .followers)
+
+            _ = try await application.createStatus(user: user,
+                                                   note: "LIST PUBLIC",
+                                                   attachmentIds: [publicAttachment.stringId()!],
+                                                   visibility: .public)
+
+            _ = try await application.createStatus(user: user,
+                                                   note: "LIST QUIET",
+                                                   attachmentIds: [quietAttachment.stringId()!],
+                                                   visibility: .quietPublic)
+
+            let followersStatus = try await application.createStatus(user: user,
+                                                                     note: "LIST FOLLOWERS",
+                                                                     attachmentIds: [followersAttachment.stringId()!],
+                                                                     visibility: .public)
+            try await application.changeStatusVisibility(statusId: followersStatus.requireID(), visibility: .followers)
+
+            let mentionedStatus = try await application.createStatus(user: user,
+                                                                     note: "LIST MENTIONED",
+                                                                     attachmentIds: [mentionedAttachment.stringId()!],
+                                                                     visibility: .public)
+            try await application.changeStatusVisibility(statusId: mentionedStatus.requireID(), visibility: .mentioned)
+
+            let otherFollowersStatus = try await application.createStatus(user: otherUser,
+                                                                          note: "LIST OTHER FOLLOWERS",
+                                                                          attachmentIds: [otherFollowersAttachment.stringId()!],
+                                                                          visibility: .public)
+            try await application.changeStatusVisibility(statusId: otherFollowersStatus.requireID(), visibility: .followers)
+
+            let otherMentionedStatus = try await application.createStatus(user: otherUser,
+                                                                          note: "LIST OTHER MENTIONED",
+                                                                          attachmentIds: [otherMentionedAttachment.stringId()!],
+                                                                          visibility: .public)
+            try await application.changeStatusVisibility(statusId: otherMentionedStatus.requireID(), visibility: .mentioned)
             
             // Act.
             let statuses = try await application.getResponse(
-                as: .user(userName: user1.userName, password: "p@ssword"),
+                as: .user(userName: user.userName, password: "p@ssword"),
                 to: "/statuses?limit=40",
                 method: .GET,
                 decodeTo: LinkableResultDto<StatusDto>.self
             )
             
             // Assert.
-            #expect(statuses.data.filter({ $0.note == "PRIVATE 1" }).first != nil, "Statuses list should contain private statuses signed in user.")
-            #expect(statuses.data.filter({ $0.note == "PRIVATE 2" }).first == nil, "Statuses list should not contain private statuses other user.")
+            #expect(statuses.data.contains(where: { $0.note == "LIST PUBLIC" }) == true, "Public status should be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "LIST QUIET" }) == true, "Quiet public status should be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "LIST FOLLOWERS" }) == true, "Own followers status should be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "LIST MENTIONED" }) == true, "Own mentioned status should be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "LIST OTHER FOLLOWERS" }) == false, "Other user followers status should not be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "LIST OTHER MENTIONED" }) == false, "Other user mentioned status should not be returned.")
+        }
+
+        @Test
+        func `Only public and quiet public statuses should be returned for unauthorized user`() async throws {
+            // Arrange.
+            let user = try await application.createUser(userName: "visibilitylistanonymous")
+
+            let publicAttachment = try await application.createAttachment(user: user)
+            let quietAttachment = try await application.createAttachment(user: user)
+            let followersAttachment = try await application.createAttachment(user: user)
+            let mentionedAttachment = try await application.createAttachment(user: user)
+            defer {
+                application.clearFiles(attachments: [publicAttachment, quietAttachment, followersAttachment, mentionedAttachment])
+            }
+
+            _ = try await application.createStatus(user: user,
+                                                   note: "ANON LIST PUBLIC",
+                                                   attachmentIds: [publicAttachment.stringId()!],
+                                                   visibility: .public)
+
+            _ = try await application.createStatus(user: user,
+                                                   note: "ANON LIST QUIET",
+                                                   attachmentIds: [quietAttachment.stringId()!],
+                                                   visibility: .quietPublic)
+
+            let followersStatus = try await application.createStatus(user: user,
+                                                                     note: "ANON LIST FOLLOWERS",
+                                                                     attachmentIds: [followersAttachment.stringId()!],
+                                                                     visibility: .public)
+            try await application.changeStatusVisibility(statusId: followersStatus.requireID(), visibility: .followers)
+
+            let mentionedStatus = try await application.createStatus(user: user,
+                                                                     note: "ANON LIST MENTIONED",
+                                                                     attachmentIds: [mentionedAttachment.stringId()!],
+                                                                     visibility: .public)
+            try await application.changeStatusVisibility(statusId: mentionedStatus.requireID(), visibility: .mentioned)
+
+            // Act.
+            let statuses = try await application.getResponse(
+                to: "/statuses?limit=40",
+                method: .GET,
+                decodeTo: LinkableResultDto<StatusDto>.self
+            )
+
+            // Assert.
+            #expect(statuses.data.contains(where: { $0.note == "ANON LIST PUBLIC" }) == true, "Public status should be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "ANON LIST QUIET" }) == true, "Quiet public status should be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "ANON LIST FOLLOWERS" }) == false, "Followers status should not be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "ANON LIST MENTIONED" }) == false, "Mentioned status should not be returned.")
         }
     }
 }

--- a/Tests/VernissageServerTests/AcceptanceTests/StatusesController/StatusesReadActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/StatusesController/StatusesReadActionTests.swift
@@ -21,7 +21,7 @@ extension ControllersTests {
         }
         
         @Test
-        func `Status should be returned for unauthorized`() async throws {
+        func `Public status should be returned for unauthorized`() async throws {
             
             // Arrange.
             let user = try await application.createUser(userName: "robinhoower")
@@ -43,54 +43,107 @@ extension ControllersTests {
             #expect(status.note == statusDto.note, "Status note should be returned.")
             #expect(statusDto.user.userName == "robinhoower", "User should be returned.")
         }
-                
+
         @Test
-        func `Other user private status should not be returned`() async throws {
-            
+        func `Quiet public status should be returned for unauthorized`() async throws {
             // Arrange.
-            let user1 = try await application.createUser(userName: "evelynhoower")
-            let user2 = try await application.createUser(userName: "fredhoower")
-            
-            let attachment1 = try await application.createAttachment(user: user1)
+            let user = try await application.createUser(userName: "quietreadstatus")
+            let attachment = try await application.createAttachment(user: user)
             defer {
-                application.clearFiles(attachments: [attachment1])
+                application.clearFiles(attachments: [attachment])
             }
-            
-            let status = try await application.createStatus(user: user1, note: "PRIVATE 1", attachmentIds: [attachment1.stringId()!], visibility: .mentioned)
-            
-            // Act.
-            let response = try await application.getErrorResponse(
-                as: .user(userName: user2.userName, password: "p@ssword"),
-                to: "/statuses/\(status.requireID())",
-                method: .GET
-            )
-            
-            // Assert.
-            #expect(response.status == HTTPResponseStatus.forbidden, "Response http status code should be forbidden (403).")
-        }
-        
-        @Test
-        func `Own private status should be returned`() async throws {
-            
-            // Arrange.
-            let user1 = try await application.createUser(userName: "stanhoower")
-            let attachment1 = try await application.createAttachment(user: user1)
-            defer {
-                application.clearFiles(attachments: [attachment1])
-            }
-            
-            let status = try await application.createStatus(user: user1, note: "PRIVATE 1", attachmentIds: [attachment1.stringId()!], visibility: .mentioned)
-            
+
+            let status = try await application.createStatus(user: user,
+                                                            note: "QUIET READ STATUS",
+                                                            attachmentIds: [attachment.stringId()!],
+                                                            visibility: .quietPublic)
+
             // Act.
             let statusDto = try await application.getResponse(
-                as: .user(userName: user1.userName, password: "p@ssword"),
                 to: "/statuses/\(status.requireID())",
                 method: .GET,
                 decodeTo: StatusDto.self
             )
-            
+
             // Assert.
-            #expect(statusDto.id != nil, "Status should be returned.")
+            #expect(statusDto.note == "QUIET READ STATUS", "Quiet public status should be returned.")
+        }
+
+        @Test
+        func `Followers and mentioned statuses should not be returned for unauthorized`() async throws {
+            
+            // Arrange.
+            let user = try await application.createUser(userName: "privateunauthorizedread")
+            let attachment1 = try await application.createAttachment(user: user)
+            let attachment2 = try await application.createAttachment(user: user)
+            defer {
+                application.clearFiles(attachments: [attachment1, attachment2])
+            }
+
+            let followersStatus = try await application.createStatus(user: user,
+                                                                     note: "FOLLOWERS READ HIDDEN",
+                                                                     attachmentIds: [attachment1.stringId()!],
+                                                                     visibility: .public)
+            try await application.changeStatusVisibility(statusId: followersStatus.requireID(), visibility: .followers)
+            let mentionedStatus = try await application.createStatus(user: user,
+                                                                     note: "MENTIONED READ HIDDEN",
+                                                                     attachmentIds: [attachment2.stringId()!],
+                                                                     visibility: .public)
+            try await application.changeStatusVisibility(statusId: mentionedStatus.requireID(), visibility: .mentioned)
+
+            // Act.
+            let followersResponse = try await application.getErrorResponse(
+                to: "/statuses/\(followersStatus.requireID())",
+                method: .GET
+            )
+            let mentionedResponse = try await application.getErrorResponse(
+                to: "/statuses/\(mentionedStatus.requireID())",
+                method: .GET
+            )
+
+            // Assert.
+            #expect(followersResponse.status == HTTPResponseStatus.notFound, "Followers status should not be returned for unauthorized user.")
+            #expect(mentionedResponse.status == HTTPResponseStatus.notFound, "Mentioned status should not be returned for unauthorized user.")
+        }
+        
+        @Test
+        func `Followers and mentioned statuses should not be returned for authorized user`() async throws {
+            // Arrange.
+            let owner = try await application.createUser(userName: "privateauthorizedowner")
+            let reader = try await application.createUser(userName: "privateauthorizedreader")
+
+            let attachment1 = try await application.createAttachment(user: owner)
+            let attachment2 = try await application.createAttachment(user: owner)
+            defer {
+                application.clearFiles(attachments: [attachment1, attachment2])
+            }
+
+            let followersStatus = try await application.createStatus(user: owner,
+                                                                     note: "FOLLOWERS AUTH HIDDEN",
+                                                                     attachmentIds: [attachment1.stringId()!],
+                                                                     visibility: .public)
+            try await application.changeStatusVisibility(statusId: followersStatus.requireID(), visibility: .followers)
+            let mentionedStatus = try await application.createStatus(user: owner,
+                                                                     note: "MENTIONED AUTH HIDDEN",
+                                                                     attachmentIds: [attachment2.stringId()!],
+                                                                     visibility: .public)
+            try await application.changeStatusVisibility(statusId: mentionedStatus.requireID(), visibility: .mentioned)
+
+            // Act.
+            let followersResponse = try await application.getErrorResponse(
+                as: .user(userName: reader.userName, password: "p@ssword"),
+                to: "/statuses/\(followersStatus.requireID())",
+                method: .GET
+            )
+            let mentionedResponse = try await application.getErrorResponse(
+                as: .user(userName: reader.userName, password: "p@ssword"),
+                to: "/statuses/\(mentionedStatus.requireID())",
+                method: .GET
+            )
+
+            // Assert.
+            #expect(followersResponse.status == HTTPResponseStatus.forbidden, "Followers status should not be returned for authorized user.")
+            #expect(mentionedResponse.status == HTTPResponseStatus.forbidden, "Mentioned status should not be returned for authorized user.")
         }
     }
 }

--- a/Tests/VernissageServerTests/AcceptanceTests/TimelinesController/TimelinesCategoryActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/TimelinesController/TimelinesCategoryActionTests.swift
@@ -148,6 +148,67 @@ extension ControllersTests {
             #expect(statusesFromApi.data[2].note == "Category note 8", "Third status is not visible.")
             #expect(statusesFromApi.data[3].note == "Category note 7", "Fourth status is not visible.")
         }
+
+        @Test
+        func `Only public statuses should be returned on category timeline`() async throws {
+            // Arrange.
+            try await application.updateSetting(key: .showCategoriesForAnonymous, value: .boolean(true))
+
+            let user = try await application.createUser(userName: "categoryvisibilityuser")
+            let category = try await application.getCategory(name: "Abstract")!
+
+            let publicAttachment = try await application.createAttachment(user: user)
+            let quietAttachment = try await application.createAttachment(user: user)
+            let followersAttachment = try await application.createAttachment(user: user)
+            let mentionedAttachment = try await application.createAttachment(user: user)
+            defer {
+                application.clearFiles(attachments: [publicAttachment, quietAttachment, followersAttachment, mentionedAttachment])
+            }
+
+            _ = try await application.createStatus(user: user,
+                                                   note: "Category visibility public",
+                                                   attachmentIds: [publicAttachment.stringId()!],
+                                                   visibility: .public,
+                                                   categoryId: category.stringId())
+
+            let quietStatus = try await application.createStatus(user: user,
+                                                                 note: "Category visibility quiet",
+                                                                 attachmentIds: [quietAttachment.stringId()!],
+                                                                 visibility: .public,
+                                                                 categoryId: category.stringId())
+            try await application.changeStatusVisibility(statusId: quietStatus.requireID(), visibility: .quietPublic)
+
+            let followersStatus = try await application.createStatus(user: user,
+                                                                     note: "Category visibility followers",
+                                                                     attachmentIds: [followersAttachment.stringId()!],
+                                                                     visibility: .public,
+                                                                     categoryId: category.stringId())
+            try await application.changeStatusVisibility(statusId: followersStatus.requireID(), visibility: .followers)
+
+            let mentionedStatus = try await application.createStatus(user: user,
+                                                                     note: "Category visibility mentioned",
+                                                                     attachmentIds: [mentionedAttachment.stringId()!],
+                                                                     visibility: .public,
+                                                                     categoryId: category.stringId())
+            try await application.changeStatusVisibility(statusId: mentionedStatus.requireID(), visibility: .mentioned)
+
+            // Act.
+            let statusesFromApi = try await application.getResponse(
+                to: "/timelines/category/\(category.name.lowercased())?limit=20",
+                method: .GET,
+                decodeTo: LinkableResultDto<StatusDto>.self
+            )
+
+            // Assert.
+            #expect(statusesFromApi.data.contains(where: { $0.note == "Category visibility public" }) == true,
+                    "Public status should be visible on category timeline.")
+            #expect(statusesFromApi.data.contains(where: { $0.note == "Category visibility quiet" }) == false,
+                    "Quiet public status should not be visible on category timeline.")
+            #expect(statusesFromApi.data.contains(where: { $0.note == "Category visibility followers" }) == false,
+                    "Followers status should not be visible on category timeline.")
+            #expect(statusesFromApi.data.contains(where: { $0.note == "Category visibility mentioned" }) == false,
+                    "Mentioned status should not be visible on category timeline.")
+        }
         
         @Test
         func `Statuses should not be returned for unauthorized when public access is disabled`() async throws {

--- a/Tests/VernissageServerTests/AcceptanceTests/TimelinesController/TimelinesFeaturedStatusesActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/TimelinesController/TimelinesFeaturedStatusesActionTests.swift
@@ -128,7 +128,7 @@ extension ControllersTests {
             #expect(statusesFromApi.data[2].note == "Since note 8", "Third status is not visible.")
             #expect(statusesFromApi.data[3].note == "Since note 7", "Fourth status is not visible.")
         }
-        
+
         @Test
         func `Statuses should not be returned when public access is disabled`() async throws {
             // Arrange.

--- a/Tests/VernissageServerTests/AcceptanceTests/TimelinesController/TimelinesHashtagActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/TimelinesController/TimelinesHashtagActionTests.swift
@@ -121,6 +121,62 @@ extension ControllersTests {
             #expect(statusesFromApi.data[2].note == "Since note #gray #blue 8", "Third status is not visible.")
             #expect(statusesFromApi.data[3].note == "Since note #gray #blue 7", "Fourth status is not visible.")
         }
+
+        @Test
+        func `Only public statuses should be returned on hashtag timeline`() async throws {
+            // Arrange.
+            try await application.updateSetting(key: .showHashtagsForAnonymous, value: .boolean(true))
+
+            let user = try await application.createUser(userName: "hashtagvisibilityuser")
+
+            let publicAttachment = try await application.createAttachment(user: user)
+            let quietAttachment = try await application.createAttachment(user: user)
+            let followersAttachment = try await application.createAttachment(user: user)
+            let mentionedAttachment = try await application.createAttachment(user: user)
+            defer {
+                application.clearFiles(attachments: [publicAttachment, quietAttachment, followersAttachment, mentionedAttachment])
+            }
+
+            _ = try await application.createStatus(user: user,
+                                                   note: "Hashtag visibility public #visibilitytest",
+                                                   attachmentIds: [publicAttachment.stringId()!],
+                                                   visibility: .public)
+
+            let quietStatus = try await application.createStatus(user: user,
+                                                                 note: "Hashtag visibility quiet #visibilitytest",
+                                                                 attachmentIds: [quietAttachment.stringId()!],
+                                                                 visibility: .public)
+            try await application.changeStatusVisibility(statusId: quietStatus.requireID(), visibility: .quietPublic)
+
+            let followersStatus = try await application.createStatus(user: user,
+                                                                     note: "Hashtag visibility followers #visibilitytest",
+                                                                     attachmentIds: [followersAttachment.stringId()!],
+                                                                     visibility: .public)
+            try await application.changeStatusVisibility(statusId: followersStatus.requireID(), visibility: .followers)
+
+            let mentionedStatus = try await application.createStatus(user: user,
+                                                                     note: "Hashtag visibility mentioned #visibilitytest",
+                                                                     attachmentIds: [mentionedAttachment.stringId()!],
+                                                                     visibility: .public)
+            try await application.changeStatusVisibility(statusId: mentionedStatus.requireID(), visibility: .mentioned)
+
+            // Act.
+            let statusesFromApi = try await application.getResponse(
+                to: "/timelines/hashtag/visibilitytest?limit=20",
+                method: .GET,
+                decodeTo: LinkableResultDto<StatusDto>.self
+            )
+
+            // Assert.
+            #expect(statusesFromApi.data.contains(where: { $0.note == "Hashtag visibility public #visibilitytest" }) == true,
+                    "Public status should be visible on hashtag timeline.")
+            #expect(statusesFromApi.data.contains(where: { $0.note == "Hashtag visibility quiet #visibilitytest" }) == false,
+                    "Quiet public status should not be visible on hashtag timeline.")
+            #expect(statusesFromApi.data.contains(where: { $0.note == "Hashtag visibility followers #visibilitytest" }) == false,
+                    "Followers status should not be visible on hashtag timeline.")
+            #expect(statusesFromApi.data.contains(where: { $0.note == "Hashtag visibility mentioned #visibilitytest" }) == false,
+                    "Mentioned status should not be visible on hashtag timeline.")
+        }
         
         @Test
         func `Statuses should not be returned for unauthorized when public access is disabled`() async throws {

--- a/Tests/VernissageServerTests/AcceptanceTests/UsersController/UsersStatusesActionTests.swift
+++ b/Tests/VernissageServerTests/AcceptanceTests/UsersController/UsersStatusesActionTests.swift
@@ -69,7 +69,7 @@ extension ControllersTests {
         }
         
         @Test
-        func `Public statuses list should be returned to other user`() async throws {
+        func `Public and quiet public statuses list should be returned to other user`() async throws {
             // Arrange.
             let user1 = try await application.createUser(userName: "wikibrin")
             let user2 = try await application.createUser(userName: "annabrin")
@@ -100,10 +100,20 @@ extension ControllersTests {
                 let smalFileUrl = URL(fileURLWithPath: "\(application.directory.workingDirectory)/Public/storage/\(attachment3.smallFile.fileName)")
                 try? FileManager.default.removeItem(at: smalFileUrl)
             }
+
+            let attachment4 = try await application.createAttachment(user: user1)
+            defer {
+                let orginalFileUrl = URL(fileURLWithPath: "\(application.directory.workingDirectory)/Public/storage/\(attachment4.originalFile.fileName)")
+                try? FileManager.default.removeItem(at: orginalFileUrl)
+
+                let smalFileUrl = URL(fileURLWithPath: "\(application.directory.workingDirectory)/Public/storage/\(attachment4.smallFile.fileName)")
+                try? FileManager.default.removeItem(at: smalFileUrl)
+            }
             
             _ = try await application.createStatus(user: user1, note: "Note 1", attachmentIds: [attachment1.stringId()!], visibility: .public)
-            _ = try await application.createStatus(user: user1, note: "Note 2", attachmentIds: [attachment2.stringId()!], visibility: .mentioned)
-            _ = try await application.createStatus(user: user1, note: "Note 3", attachmentIds: [attachment3.stringId()!], visibility: .followers)
+            _ = try await application.createStatus(user: user1, note: "Note 2", attachmentIds: [attachment2.stringId()!], visibility: .quietPublic)
+            _ = try await application.createStatus(user: user1, note: "Note 3", attachmentIds: [attachment3.stringId()!], visibility: .mentioned)
+            _ = try await application.createStatus(user: user1, note: "Note 4", attachmentIds: [attachment4.stringId()!], visibility: .followers)
             
             // Act.
             let statuses = try await application.getResponse(
@@ -114,11 +124,15 @@ extension ControllersTests {
             )
             
             // Assert.
-            #expect(statuses.data.count == 1, "Public statuses list should be returned.")
+            #expect(statuses.data.count == 2, "Public and quiet public statuses list should be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "Note 1" }) == true, "Public status should be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "Note 2" }) == true, "Quiet public status should be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "Note 3" }) == false, "Mentioned status should not be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "Note 4" }) == false, "Followers status should not be returned.")
         }
         
         @Test
-        func `Public statuses list should be returned for unauthorized user`() async throws {
+        func `Public and quiet public statuses list should be returned for unauthorized user`() async throws {
             // Arrange.
             let user = try await application.createUser(userName: "adrianbrin")
             
@@ -148,10 +162,20 @@ extension ControllersTests {
                 let smalFileUrl = URL(fileURLWithPath: "\(application.directory.workingDirectory)/Public/storage/\(attachment3.smallFile.fileName)")
                 try? FileManager.default.removeItem(at: smalFileUrl)
             }
+
+            let attachment4 = try await application.createAttachment(user: user)
+            defer {
+                let orginalFileUrl = URL(fileURLWithPath: "\(application.directory.workingDirectory)/Public/storage/\(attachment4.originalFile.fileName)")
+                try? FileManager.default.removeItem(at: orginalFileUrl)
+
+                let smalFileUrl = URL(fileURLWithPath: "\(application.directory.workingDirectory)/Public/storage/\(attachment4.smallFile.fileName)")
+                try? FileManager.default.removeItem(at: smalFileUrl)
+            }
             
             _ = try await application.createStatus(user: user, note: "Note 1", attachmentIds: [attachment1.stringId()!], visibility: .public)
-            _ = try await application.createStatus(user: user, note: "Note 2", attachmentIds: [attachment2.stringId()!], visibility: .mentioned)
-            _ = try await application.createStatus(user: user, note: "Note 3", attachmentIds: [attachment3.stringId()!], visibility: .followers)
+            _ = try await application.createStatus(user: user, note: "Note 2", attachmentIds: [attachment2.stringId()!], visibility: .quietPublic)
+            _ = try await application.createStatus(user: user, note: "Note 3", attachmentIds: [attachment3.stringId()!], visibility: .mentioned)
+            _ = try await application.createStatus(user: user, note: "Note 4", attachmentIds: [attachment4.stringId()!], visibility: .followers)
             
             // Act.
             let statuses = try await application.getResponse(
@@ -161,7 +185,11 @@ extension ControllersTests {
             )
             
             // Assert.
-            #expect(statuses.data.count == 1, "Public statuses list should be returned.")
+            #expect(statuses.data.count == 2, "Public and quiet public statuses list should be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "Note 1" }) == true, "Public status should be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "Note 2" }) == true, "Quiet public status should be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "Note 3" }) == false, "Mentioned status should not be returned.")
+            #expect(statuses.data.contains(where: { $0.note == "Note 4" }) == false, "Followers status should not be returned.")
         }
 
         @Test

--- a/Tests/VernissageServerTests/ServicesTests/ActivityPubServiceAnnounceTests.swift
+++ b/Tests/VernissageServerTests/ServicesTests/ActivityPubServiceAnnounceTests.swift
@@ -1,0 +1,86 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import Vapor
+import Testing
+import Queues
+import ActivityPubKit
+import Fluent
+
+@Suite("ActivityPubService (Announce)", .serialized)
+struct ActivityPubServiceAnnounceTests {
+
+    var application: Application!
+
+    init() async throws {
+        self.application = try await ApplicationManager.shared.application()
+    }
+
+    @Test
+    func `Duplicate announce delivered to inboxes should create single reblog`() async throws {
+        // Arrange.
+        let activityPubService = ActivityPubService()
+        let queueContext = application.getQueueContext(queueName: QueueName(string: "ActivityPubSharedInboxJob"))
+
+        let statusOwner = try await application.createUser(userName: "announceownerlocal")
+        let announcer = try await application.createUser(userName: "announcerremote", isLocal: false)
+
+        let attachment = try await application.createAttachment(user: statusOwner)
+        defer {
+            application.clearFiles(attachments: [attachment])
+        }
+        let status = try await application.createStatus(user: statusOwner,
+                                                        note: "Status to be announced once",
+                                                        attachmentIds: [attachment.stringId()!])
+
+        let activityId = "https://remote.example/activities/announce-duplicate-1"
+        let activity = ActivityDto(context: .single(ContextDto(value: "https://www.w3.org/ns/activitystreams")),
+                                   type: .announce,
+                                   id: activityId,
+                                   actor: .single(ActorDto(id: announcer.activityPubProfile)),
+                                   to: nil,
+                                   cc: nil,
+                                   object: .single(ObjectDto(id: status.activityPubId)),
+                                   summary: nil,
+                                   signature: nil,
+                                   published: Date().toISO8601String())
+
+        let sharedInboxRequest = ActivityPubRequestDto(activity: activity,
+                                                       headers: [:],
+                                                       bodyHash: nil,
+                                                       bodyValue: "{}",
+                                                       httpMethod: .post,
+                                                       httpPath: .sharedInbox,
+                                                       receivedAt: Date.now)
+
+        let userInboxRequest = ActivityPubRequestDto(activity: activity,
+                                                     headers: [:],
+                                                     bodyHash: nil,
+                                                     bodyValue: "{}",
+                                                     httpMethod: .post,
+                                                     httpPath: .userInbox(statusOwner.userName),
+                                                     receivedAt: Date.now)
+
+        // Act.
+        try await activityPubService.announce(activityPubRequest: sharedInboxRequest, on: queueContext.executionContext)
+        try await activityPubService.announce(activityPubRequest: userInboxRequest, on: queueContext.executionContext)
+
+        // Assert.
+        let reblogs = try await Status.query(on: application.db)
+            .filter(\.$user.$id == announcer.requireID())
+            .filter(\.$reblog.$id == status.requireID())
+            .all()
+
+        #expect(reblogs.count == 1, "Only one reblog should be created for duplicated announce delivery.")
+
+        let refreshedStatus = try await Status.query(on: application.db)
+            .filter(\.$id == status.requireID())
+            .first()
+
+        #expect(refreshedStatus?.reblogsCount == 1, "Reblogs counter should be incremented only once.")
+    }
+}

--- a/Tests/VernissageServerTests/ServicesTests/ActivityPubServiceCreateTests.swift
+++ b/Tests/VernissageServerTests/ServicesTests/ActivityPubServiceCreateTests.swift
@@ -1,0 +1,328 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+@testable import VernissageServer
+import Vapor
+import Testing
+import Queues
+import ActivityPubKit
+import Fluent
+
+@Suite("ActivityPubService (Create)", .serialized)
+struct ActivityPubServiceCreateTests {
+    let externalImageUrl = "https://joinvernissage.org/images/001.png?v=tmnnh3o0"
+
+    var application: Application!
+
+    init() async throws {
+        self.application = try await ApplicationManager.shared.application()
+    }
+
+    @Test
+    func `Followers create delivered to user inbox should stay followers-only`() async throws {
+        // Arrange.
+        let activityPubService = ActivityPubService()
+        let queueContext = application.getQueueContext(queueName: QueueName(string: "ActivityPubUserInboxJob"))
+
+        let sourceUser = try await application.createUser(userName: "remotefollowerscreate", isLocal: false)
+
+        let recipientUser = try await application.createUser(userName: "followersrecipient")
+        _ = try await application.createUser(userName: "followersnonrecipient")
+
+        _ = try await application.createFollow(sourceId: recipientUser.requireID(), targetId: sourceUser.requireID(), approved: true)
+
+        let attachment = try await application.createAttachment(user: recipientUser)
+        defer {
+            application.clearFiles(attachments: [attachment])
+        }
+        let parentStatus = try await application.createStatus(user: recipientUser,
+                                                              note: "Parent for followers-only comment",
+                                                              attachmentIds: [attachment.stringId()!])
+
+        let noteId = "https://remote.example/statuses/followers-only-create-1"
+        let noteDto = NoteDto(id: noteId,
+                              summary: nil,
+                              inReplyTo: parentStatus.activityPubId,
+                              published: Date().toISO8601String(),
+                              updated: nil,
+                              url: noteId,
+                              attributedTo: sourceUser.activityPubProfile,
+                              to: .single(ActorDto(id: "\(sourceUser.activityPubProfile)/followers")),
+                              cc: nil,
+                              sensitive: false,
+                              atomUri: nil,
+                              inReplyToAtomUri: nil,
+                              conversation: nil,
+                              content: "Followers only create.",
+                              attachment: nil,
+                              tag: nil)
+
+        let activity = ActivityDto(context: .single(ContextDto(value: "https://www.w3.org/ns/activitystreams")),
+                                   type: .create,
+                                   id: "\(noteId)/activity",
+                                   actor: .single(ActorDto(id: sourceUser.activityPubProfile)),
+                                   to: noteDto.to,
+                                   cc: noteDto.cc,
+                                   object: .single(ObjectDto(id: noteDto.id, type: .note, object: noteDto)),
+                                   summary: nil,
+                                   signature: nil,
+                                   published: noteDto.published)
+
+        let request = ActivityPubRequestDto(activity: activity,
+                                            headers: [:],
+                                            bodyHash: nil,
+                                            bodyValue: "{}",
+                                            httpMethod: .post,
+                                            httpPath: .userInbox(recipientUser.userName),
+                                            receivedAt: Date.now)
+
+        // Act.
+        try await activityPubService.create(activityPubRequest: request, on: queueContext.executionContext)
+
+        // Assert.
+        let status = try await Status.query(on: application.db)
+            .filter(\.$activityPubId == noteId)
+            .first()
+
+        let createdStatus = try #require(status)
+        #expect(createdStatus.visibility == .followers, "Status visibility should be followers.")
+        #expect(createdStatus.$replyToStatus.id == parentStatus.id, "Comment should be linked to parent status.")
+    }
+
+    @Test
+    func `Mentioned create delivered to user inbox should be accepted even if actor is not followed`() async throws {
+        // Arrange.
+        let activityPubService = ActivityPubService()
+        let queueContext = application.getQueueContext(queueName: QueueName(string: "ActivityPubUserInboxJob"))
+
+        let sourceUser = try await application.createUser(userName: "remotementionedcreate", isLocal: false)
+
+        let mentionedRecipient = try await application.createUser(userName: "mentionedrecipient")
+        let attachment = try await application.createAttachment(user: mentionedRecipient)
+        defer {
+            application.clearFiles(attachments: [attachment])
+        }
+        let parentStatus = try await application.createStatus(user: mentionedRecipient,
+                                                              note: "Parent for mentioned-only comment",
+                                                              attachmentIds: [attachment.stringId()!])
+
+        let noteId = "https://remote.example/statuses/mentioned-only-create-1"
+        let noteDto = NoteDto(id: noteId,
+                              summary: nil,
+                              inReplyTo: parentStatus.activityPubId,
+                              published: Date().toISO8601String(),
+                              updated: nil,
+                              url: noteId,
+                              attributedTo: sourceUser.activityPubProfile,
+                              to: .single(ActorDto(id: mentionedRecipient.activityPubProfile)),
+                              cc: nil,
+                              sensitive: false,
+                              atomUri: nil,
+                              inReplyToAtomUri: nil,
+                              conversation: nil,
+                              content: "Direct mentioned create.",
+                              attachment: nil,
+                              tag: nil)
+
+        let activity = ActivityDto(context: .single(ContextDto(value: "https://www.w3.org/ns/activitystreams")),
+                                   type: .create,
+                                   id: "\(noteId)/activity",
+                                   actor: .single(ActorDto(id: sourceUser.activityPubProfile)),
+                                   to: noteDto.to,
+                                   cc: noteDto.cc,
+                                   object: .single(ObjectDto(id: noteDto.id, type: .note, object: noteDto)),
+                                   summary: nil,
+                                   signature: nil,
+                                   published: noteDto.published)
+
+        let request = ActivityPubRequestDto(activity: activity,
+                                            headers: [:],
+                                            bodyHash: nil,
+                                            bodyValue: "{}",
+                                            httpMethod: .post,
+                                            httpPath: .userInbox(mentionedRecipient.userName),
+                                            receivedAt: Date.now)
+
+        // Act.
+        try await activityPubService.create(activityPubRequest: request, on: queueContext.executionContext)
+
+        // Assert.
+        let status = try await Status.query(on: application.db)
+            .filter(\.$activityPubId == noteId)
+            .first()
+
+        let createdStatus = try #require(status)
+        #expect(createdStatus.visibility == .mentioned, "Status visibility should be mentioned.")
+        #expect(createdStatus.$replyToStatus.id == parentStatus.id, "Comment should be linked to parent status.")
+    }
+
+    @Test
+    func `Mentioned create delivered to user inbox should be rejected when recipient is not in addressing`() async throws {
+        // Arrange.
+        let activityPubService = ActivityPubService()
+        let queueContext = application.getQueueContext(queueName: QueueName(string: "ActivityPubUserInboxJob"))
+
+        let sourceUser = try await application.createUser(userName: "remotementionedwrongrecipient", isLocal: false)
+        let inboxRecipient = try await application.createUser(userName: "mentionedwrongrecipient")
+        let explicitlyAddressedRecipient = try await application.createUser(userName: "mentionedexplicitrecipient")
+
+        let attachment = try await application.createAttachment(user: inboxRecipient)
+        defer {
+            application.clearFiles(attachments: [attachment])
+        }
+        let parentStatus = try await application.createStatus(user: inboxRecipient,
+                                                              note: "Parent for mentioned mismatch comment",
+                                                              attachmentIds: [attachment.stringId()!])
+
+        let noteId = "https://remote.example/statuses/mentioned-wrong-recipient-create-1"
+        let noteDto = NoteDto(id: noteId,
+                              summary: nil,
+                              inReplyTo: parentStatus.activityPubId,
+                              published: Date().toISO8601String(),
+                              updated: nil,
+                              url: noteId,
+                              attributedTo: sourceUser.activityPubProfile,
+                              to: .single(ActorDto(id: explicitlyAddressedRecipient.activityPubProfile)),
+                              cc: nil,
+                              sensitive: false,
+                              atomUri: nil,
+                              inReplyToAtomUri: nil,
+                              conversation: nil,
+                              content: "Mentioned create delivered to wrong inbox recipient.",
+                              attachment: nil,
+                              tag: nil)
+
+        let activity = ActivityDto(context: .single(ContextDto(value: "https://www.w3.org/ns/activitystreams")),
+                                   type: .create,
+                                   id: "\(noteId)/activity",
+                                   actor: .single(ActorDto(id: sourceUser.activityPubProfile)),
+                                   to: noteDto.to,
+                                   cc: noteDto.cc,
+                                   object: .single(ObjectDto(id: noteDto.id, type: .note, object: noteDto)),
+                                   summary: nil,
+                                   signature: nil,
+                                   published: noteDto.published)
+
+        let request = ActivityPubRequestDto(activity: activity,
+                                            headers: [:],
+                                            bodyHash: nil,
+                                            bodyValue: "{}",
+                                            httpMethod: .post,
+                                            httpPath: .userInbox(inboxRecipient.userName),
+                                            receivedAt: Date.now)
+
+        // Act.
+        try await activityPubService.create(activityPubRequest: request, on: queueContext.executionContext)
+
+        // Assert.
+        let status = try await Status.query(on: application.db)
+            .filter(\.$activityPubId == noteId)
+            .first()
+
+        #expect(status == nil, "Status should not be created when user inbox recipient is not addressed.")
+    }
+
+    @Test
+    func `Public create delivered to user inbox should be added to followers timeline and public timeline`() async throws {
+        // Arrange.
+        let activityPubService = ActivityPubService()
+        let queueContext = application.getQueueContext(queueName: QueueName(string: "ActivityPubUserInboxJob"))
+        let timelineService = application.services.timelineService
+
+        let sourceUser = try await application.createUser(userName: "remotepubliccreate", isLocal: false)
+        let followerRecipient = try await application.createUser(userName: "publicfollowerrecipient")
+        let nonFollowerRecipient = try await application.createUser(userName: "publicnonfollowerrecipient")
+
+        _ = try await application.createFollow(sourceId: followerRecipient.requireID(), targetId: sourceUser.requireID(), approved: true)
+
+        let noteId = "https://remote.example/statuses/public-create-1"
+        let noteDto = NoteDto(id: noteId,
+                              summary: nil,
+                              inReplyTo: nil,
+                              published: Date().toISO8601String(),
+                              updated: nil,
+                              url: noteId,
+                              attributedTo: sourceUser.activityPubProfile,
+                              to: .single(ActorDto(id: "https://www.w3.org/ns/activitystreams#Public")),
+                              cc: .single(ActorDto(id: "\(sourceUser.activityPubProfile)/followers")),
+                              sensitive: false,
+                              atomUri: nil,
+                              inReplyToAtomUri: nil,
+                              conversation: nil,
+                              content: "Public create delivered to user inbox.",
+                              attachment: [
+                                MediaAttachmentDto(mediaType: "image/png",
+                                                   url: externalImageUrl,
+                                                   name: "Public image",
+                                                   blurhash: "LEHV6nWB2yk8pyo0adR*.7kCMdnj",
+                                                   width: 1706,
+                                                   height: 882,
+                                                   hdrImageUrl: nil,
+                                                   exif: nil,
+                                                   exifData: nil,
+                                                   location: nil)
+                              ],
+                              tag: nil)
+
+        let activity = ActivityDto(context: .single(ContextDto(value: "https://www.w3.org/ns/activitystreams")),
+                                   type: .create,
+                                   id: "\(noteId)/activity",
+                                   actor: .single(ActorDto(id: sourceUser.activityPubProfile)),
+                                   to: noteDto.to,
+                                   cc: noteDto.cc,
+                                   object: .single(ObjectDto(id: noteDto.id, type: .note, object: noteDto)),
+                                   summary: nil,
+                                   signature: nil,
+                                   published: noteDto.published)
+
+        let request = ActivityPubRequestDto(activity: activity,
+                                            headers: [:],
+                                            bodyHash: nil,
+                                            bodyValue: "{}",
+                                            httpMethod: .post,
+                                            httpPath: .userInbox(followerRecipient.userName),
+                                            receivedAt: Date.now)
+
+        // Act.
+        try await activityPubService.create(activityPubRequest: request, on: queueContext.executionContext)
+
+        // Assert.
+        let status = try await Status.query(on: application.db)
+            .filter(\.$activityPubId == noteId)
+            .first()
+
+        let createdStatus = try #require(status)
+        let createdStatusId = try createdStatus.requireID()
+        #expect(createdStatus.visibility == .public, "Status visibility should be public.")
+
+        let followerUserStatus = try await UserStatus.query(on: application.db)
+            .filter(\.$status.$id == createdStatusId)
+            .filter(\.$user.$id == followerRecipient.requireID())
+            .first()
+
+        #expect(followerUserStatus != nil, "Public status should be added to follower timeline.")
+
+        let nonFollowerUserStatus = try await UserStatus.query(on: application.db)
+            .filter(\.$status.$id == createdStatusId)
+            .filter(\.$user.$id == nonFollowerRecipient.requireID())
+            .first()
+
+        #expect(nonFollowerUserStatus == nil, "Public status should not be added to non-follower home timeline.")
+
+        let publicStatuses = try await timelineService.public(linkableParams: LinkableParams(maxId: nil, minId: nil, sinceId: nil, limit: 40),
+                                                              onlyLocal: false,
+                                                              forUserId: nil,
+                                                              on: queueContext.executionContext)
+        #expect(publicStatuses.contains(where: { $0.id == createdStatus.id }), "Public status should be visible in public timeline.")
+
+        let attachments = try await Attachment.query(on: application.db)
+            .filter(\.$status.$id == createdStatusId)
+            .with(\.$originalFile)
+            .with(\.$smallFile)
+            .all()
+        application.clearFiles(attachments: attachments)
+    }
+}

--- a/Tests/VernissageServerTests/ServicesTests/StatusesServiceTests.swift
+++ b/Tests/VernissageServerTests/ServicesTests/StatusesServiceTests.swift
@@ -413,6 +413,7 @@ struct StatusesServiceTests {
         let queueContext = application.getQueueContext(queueName: QueueName(string: "ActivityPubSharedInboxJob"))
         _ = try await statusesService.create(basedOn: noteDto,
                                              userId: remoteCommentAuthor.requireID(),
+                                             visibility: .public,
                                              on: queueContext.executionContext)
 
         // Assert.


### PR DESCRIPTION
Ne mechanism for calculating and validating visibility during create/announce actions from ActivityPub has been implemented.