### PR TITLE
#567 Change size of description column for attachments

### DIFF
--- a/Sources/VernissageServer/Application+Migrations.swift
+++ b/Sources/VernissageServer/Application+Migrations.swift
@@ -210,5 +210,7 @@ extension Application {
         self.migrations.add(Status.CreateActivityPubUrlIndex())
         self.migrations.add(User.CreateMovedToUserIdIndex())
         self.migrations.add(Article.AddLanguage())
+        self.migrations.add(Attachment.ChangeDescriptionLength())
+        self.migrations.add(AttachmentHistory.ChangeDescriptionLength())
     }
 }

--- a/Sources/VernissageServer/Migrations/CreateAttachmentHistories.swift
+++ b/Sources/VernissageServer/Migrations/CreateAttachmentHistories.swift
@@ -7,6 +7,7 @@
 import Vapor
 import Fluent
 import SQLKit
+import SQLiteKit
 
 extension AttachmentHistory {
     struct CreateAttachmentHistories: AsyncMigration {
@@ -116,6 +117,32 @@ extension AttachmentHistory {
                     .on(AttachmentHistory.schema)
                     .run()
             }
+        }
+    }
+
+    struct ChangeDescriptionLength: AsyncMigration {
+        func prepare(on database: Database) async throws {
+            // SQLite only supports adding columns in ALTER TABLE statements.
+            if let _ = database as? SQLiteDatabase {
+                return
+            }
+
+            try await database
+                .schema(AttachmentHistory.schema)
+                .updateField("description", .varchar(10_000))
+                .update()
+        }
+
+        func revert(on database: Database) async throws {
+            // SQLite only supports adding columns in ALTER TABLE statements.
+            if let _ = database as? SQLiteDatabase {
+                return
+            }
+
+            try await database
+                .schema(AttachmentHistory.schema)
+                .updateField("description", .varchar(2_000))
+                .update()
         }
     }
 }

--- a/Sources/VernissageServer/Migrations/CreateAttachments.swift
+++ b/Sources/VernissageServer/Migrations/CreateAttachments.swift
@@ -7,6 +7,7 @@
 import Vapor
 import Fluent
 import SQLKit
+import SQLiteKit
 
 extension Attachment {
     struct CreateAttachments: AsyncMigration {
@@ -174,6 +175,32 @@ extension Attachment {
                     .on(Attachment.schema)
                     .run()
             }
+        }
+    }
+
+    struct ChangeDescriptionLength: AsyncMigration {
+        func prepare(on database: Database) async throws {
+            // SQLite only supports adding columns in ALTER TABLE statements.
+            if let _ = database as? SQLiteDatabase {
+                return
+            }
+
+            try await database
+                .schema(Attachment.schema)
+                .updateField("description", .varchar(10_000))
+                .update()
+        }
+
+        func revert(on database: Database) async throws {
+            // SQLite only supports adding columns in ALTER TABLE statements.
+            if let _ = database as? SQLiteDatabase {
+                return
+            }
+
+            try await database
+                .schema(Attachment.schema)
+                .updateField("description", .varchar(2_000))
+                .update()
         }
     }
 }


### PR DESCRIPTION
Some platforms have much bigger description field than 2000 characters (e.g mastodon now have 10000 characters limit).