### PR TITLE
Fix Video deserialization issue

### DIFF
--- a/Sources/ActivityPubKit/Entities/NoteDto.swift
+++ b/Sources/ActivityPubKit/Entities/NoteDto.swift
@@ -9,7 +9,7 @@ import Foundation
 public struct NoteDto: CommonObjectDto {
     public let context: ComplexType<ContextDto>?
     public let id: String
-    public let type = "Note"
+    public let type: String
     public let summary: String?
     public let inReplyToRaw: ComplexType<ReplyToDto>?
     public let published: String?
@@ -49,6 +49,7 @@ public struct NoteDto: CommonObjectDto {
     
     public init(
         id: String,
+        type: String = "Note",
         summary: String?,
         inReplyTo: String?,
         published: String?,
@@ -67,6 +68,7 @@ public struct NoteDto: CommonObjectDto {
     ) {
         self.context = ContextDto.createNoteContext()
         self.id = id
+        self.type = type
         self.summary = summary
         self.published = published
         self.updated = updated
@@ -135,7 +137,32 @@ extension ComplexType<ReplyToDto> {
     }
 }
 
-extension NoteDto: Codable { }
+extension NoteDto: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.context = try container.decodeIfPresent(ComplexType<ContextDto>.self, forKey: .context)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.type = try container.decode(String.self, forKey: .type)
+        self.summary = try container.decodeIfPresent(String.self, forKey: .summary)
+        self.inReplyToRaw = try container.decodeIfPresent(ComplexType<ReplyToDto>.self, forKey: .inReplyToRaw)
+        self.published = try container.decodeIfPresent(String.self, forKey: .published)
+        self.updated = try container.decodeIfPresent(String.self, forKey: .updated)
+        self.urlRaw = try container.decodeIfPresent(ComplexType<UrlDto>.self, forKey: .urlRaw)
+
+        let attributedTo = try container.decode(ComplexType<ActorDto>.self, forKey: .attributedTo)
+        self.attributedTo = attributedTo.actorIds().first ?? ""
+
+        self.to = try container.decodeIfPresent(ComplexType<ActorDto>.self, forKey: .to)
+        self.cc = try container.decodeIfPresent(ComplexType<ActorDto>.self, forKey: .cc)
+        self.sensitive = try container.decodeIfPresent(Bool.self, forKey: .sensitive)
+        self.atomUri = try container.decodeIfPresent(String.self, forKey: .atomUri)
+        self.inReplyToAtomUri = try container.decodeIfPresent(String.self, forKey: .inReplyToAtomUri)
+        self.conversation = try container.decodeIfPresent(String.self, forKey: .conversation)
+        self.content = try container.decodeIfPresent(String.self, forKey: .content)
+        self.attachment = try container.decodeIfPresent([MediaAttachmentDto].self, forKey: .attachment)
+        self.tag = try container.decodeIfPresent(ComplexType<NoteTagDto>.self, forKey: .tag)
+    }
+}
 
 
 extension ComplexType<NoteTagDto> {

--- a/Sources/ActivityPubKit/Entities/UrlDto.swift
+++ b/Sources/ActivityPubKit/Entities/UrlDto.swift
@@ -61,6 +61,19 @@ fileprivate struct UrlDataDto {
     public let href: String
     public let type: UrlTypeDto?
     public let rel: String?
+
+    enum CodingKeys: String, CodingKey {
+        case href
+        case type
+        case rel
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.href = try container.decode(String.self, forKey: .href)
+        self.type = try container.decodeIfPresent(UrlTypeDto.self, forKey: .type)
+        self.rel = try container.decodeIfPresent(ComplexType<String>.self, forKey: .rel)?.values().first
+    }
 }
 
-extension UrlDataDto: Codable { }
+extension UrlDataDto: Decodable { }

--- a/Sources/VernissageServer/Errors/ActivityPubError.swift
+++ b/Sources/VernissageServer/Errors/ActivityPubError.swift
@@ -35,6 +35,7 @@ enum ActivityPubError: Error {
     case missingSharedInboxUrl(String)
     case statusHasNotBeenDownloaded(String, String)
     case statusCannotBeProcessed(String, String)
+    case statusTypeNotSupported(String, String)
     case missingSupportedImageAttachments(String)
     case actorNotDownloaded(String)
     case invalidNoteUrl(String)
@@ -81,6 +82,7 @@ extension ActivityPubError: LocalizedTerminateError {
         case .missingSharedInboxUrl(let activityPubProfile): return "Missing shared inbox in local database for user: '\(activityPubProfile)'."
         case .statusHasNotBeenDownloaded(let statusActivityPubUrl, let errorDescription): return "Downloaded status is empty: \(statusActivityPubUrl). Error: \(errorDescription)"
         case .statusCannotBeProcessed(let statusActivityPubUrl, let errorDescription): return "Downloaded status cannot be processed: \(statusActivityPubUrl). Error: \(errorDescription)"
+        case .statusTypeNotSupported(let statusActivityPubUrl, let type): return "Downloaded object type '\(type)' is not supported: \(statusActivityPubUrl)."
         case .missingSupportedImageAttachments(let statusActivityPubUrl): return "Downloaded status does not have image attachments: \(statusActivityPubUrl)."
         case .actorNotDownloaded(let statusActivityPubUrl): return "Error during downloading actor from remote server: \(statusActivityPubUrl)."
         case .invalidNoteUrl(let statusActivityPubUrl): return "Invalid URL to status: \(statusActivityPubUrl)."
@@ -115,6 +117,8 @@ extension ActivityPubError: LocalizedTerminateError {
             return ["statusActivityPubUrl": statusActivityPubUrl, "errorDescription": errorDescription]
         case .statusCannotBeProcessed(let statusActivityPubUrl, let errorDescription):
             return ["statusActivityPubUrl": statusActivityPubUrl, "errorDescription": errorDescription]
+        case .statusTypeNotSupported(let statusActivityPubUrl, let type):
+            return ["statusActivityPubUrl": statusActivityPubUrl, "type": type]
         case .missingSupportedImageAttachments(let statusActivityPubUrl): return ["statusActivityPubUrl": statusActivityPubUrl]
         case .actorNotDownloaded(let statusActivityPubUrl): return ["statusActivityPubUrl": statusActivityPubUrl]
         case .invalidNoteUrl(let statusActivityPubUrl): return ["statusActivityPubUrl": statusActivityPubUrl]
@@ -160,6 +164,7 @@ extension ActivityPubError: LocalizedTerminateError {
         case .missingSharedInboxUrl: return "missingSharedInboxUrl"
         case .statusHasNotBeenDownloaded: return "statusHasNotBeenDownloaded"
         case .statusCannotBeProcessed: return "statusCannotBeProcessed"
+        case .statusTypeNotSupported: return "statusTypeNotSupported"
         case .missingSupportedImageAttachments: return "missingSupportedImageAttachments"
         case .actorNotDownloaded: return "actorNotDownloaded"
         case .invalidNoteUrl: return "invalidNoteUrl"

--- a/Sources/VernissageServer/Services/ActivityPubDownloadStatusService.swift
+++ b/Sources/VernissageServer/Services/ActivityPubDownloadStatusService.swift
@@ -63,6 +63,11 @@ final class ActivityPubDownloadStatusService: ActivityPubDownloadStatusServiceTy
             return status
         }
 
+        guard noteDto.type == "Note" else {
+            context.logger.warning("Downloaded object type '\(noteDto.type)' is not supported (status: \(noteDto.id)).")
+            throw ActivityPubError.statusTypeNotSupported(noteDto.id, noteDto.type)
+        }
+
         // We cannot save statuses from blocked actors (via announce or search).
         if try await instanceBlockedUsersService.isActorBlockedByInstance(activityPubId: noteDto.attributedTo, on: context) {
             context.logger.info("Actor (\(noteDto.attributedTo)) of downloaded status is blocked by the instance.")

--- a/Sources/VernissageServer/Services/ActivityPubIncomingService.swift
+++ b/Sources/VernissageServer/Services/ActivityPubIncomingService.swift
@@ -248,6 +248,11 @@ final class ActivityPubIncomingService: ActivityPubIncomingServiceType {
                     continue
                 }
 
+                guard noteDto.type == "Note" else {
+                    context.logger.warning("Object type '\(noteDto.type)' is not supported (status: \(noteDto.id), activity: \(activity.id)).")
+                    continue
+                }
+
                 guard let activityPubProfile = activity.actor.actorIds().first else {
                     context.logger.warning("Cannot find any ActivityPub actor profile id (activity: \(activity.id)).")
                     continue
@@ -909,6 +914,8 @@ final class ActivityPubIncomingService: ActivityPubIncomingServiceType {
             return downloadedStatus
         } catch ActivityPubError.missingSupportedImageAttachments {
             // Consume this kind of error (it’s not a real error - statuses without images are simply not supported).
+        } catch ActivityPubError.statusTypeNotSupported {
+            // Consume this kind of error (unsupported ActivityStreams object types are intentionally ignored).
         } catch StatusError.cannotAddCommentWithoutCommentedStatus {
             // Consume this kind of error (it’s not a real error - we cannot create comment to not exists status).
         } catch ActivityPubError.actorIsSuppressedByInstance {
@@ -1265,6 +1272,7 @@ final class ActivityPubIncomingService: ActivityPubIncomingServiceType {
                                       activityPubProfile: String,
                                       on context: ExecutionContext) async throws -> Bool {
         guard activity.type == .create,
+              noteDto.type == "Note",
               noteDto.isComment() == false,
               let attachments = noteDto.attachment,
               attachments.isEmpty == false,

--- a/Sources/VernissageServer/Services/CollectionsService.swift
+++ b/Sources/VernissageServer/Services/CollectionsService.swift
@@ -87,6 +87,11 @@ final class CollectionsService: CollectionsServiceType {
                let noteDto = featuredCollectionData.statusNotes[featuredStatusId],
                noteDto.attributedTo == user.activityPubProfile {
 
+                guard noteDto.type == "Note" else {
+                    context.logger.warning("Featured collection object type '\(noteDto.type)' is not supported (status: \(featuredStatusId)).")
+                    continue
+                }
+
                 // Prevent creating new statuses when status doesn't contains any image.
                 guard let attachments = noteDto.attachment, !attachments.isEmpty, attachments.hasSupportedImages() else {
                     context.logger.warning("Featured collection note doesn't contain supported image attachments (status: \(featuredStatusId)).")

--- a/Tests/ActivityPubKitTests/ActivityDtoDeserialization.swift
+++ b/Tests/ActivityPubKitTests/ActivityDtoDeserialization.swift
@@ -325,6 +325,20 @@ struct ActivityDtoDeserialization {
         #expect(noteDto.id == "https://bsky.brid.gy/convert/ap/at://did:plc:hf7ezrajxadu7v3tzcyij424/app.bsky.feed.post/3mhg4lxsz2s25", "Note id should deserialize correctly")
         #expect(noteDto.inReplyTo == "https://bsky.brid.gy/convert/ap/at://did:plc:hf7ezrajxadu7v3tzcyij424/app.bsky.feed.post/3mhg4guilx225", "Property 'inReplyTo' is not valid.")
     }
+
+    @Test
+    func `JSON from PeerTube should deserialize`() throws {
+        let jsonData = try #require(ActivityDtoDeserializationFixtures.statusCase10.data(using: .utf8))
+
+        // Act.
+        let noteDto = try self.decoder.decode(NoteDto.self, from: jsonData)
+
+        // Assert.
+        #expect(noteDto.id == "https://tube.funfacts.de/videos/watch/c8935468-d4e2-4d0e-9553-861339374554")
+        #expect(noteDto.type == "Video")
+        #expect(noteDto.url == "https://tube.funfacts.de/w/qLxh9z5j9Js68HFnb8r8Bj")
+        #expect(noteDto.attributedTo == "https://tube.funfacts.de/accounts/funfacts")
+    }
     
     @Test
     func `JSON with person string and tag as s string should deserialize`() throws {
@@ -352,4 +366,3 @@ struct ActivityDtoDeserialization {
         )
     }
 }
-

--- a/Tests/ActivityPubKitTests/ActivityDtoDeserializationFixtures.swift
+++ b/Tests/ActivityPubKitTests/ActivityDtoDeserializationFixtures.swift
@@ -1176,5 +1176,41 @@ enum ActivityDtoDeserializationFixtures {
   }
 }
 """
+    static let statusCase10 =
+"""
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams"
+  ],
+  "id": "https://tube.funfacts.de/videos/watch/c8935468-d4e2-4d0e-9553-861339374554",
+  "type": "Video",
+  "attributedTo": [
+    {
+      "type": "Person",
+      "id": "https://tube.funfacts.de/accounts/funfacts"
+    },
+    {
+      "type": "Group",
+      "id": "https://tube.funfacts.de/video-channels/funfacts.de"
+    }
+  ],
+  "url": [
+    {
+      "type": "Link",
+      "mediaType": "text/html",
+      "href": "https://tube.funfacts.de/w/qLxh9z5j9Js68HFnb8r8Bj"
+    },
+    {
+      "type": "Link",
+      "rel": [
+        "metadata",
+        "video/mp4"
+      ],
+      "mediaType": "application/json",
+      "href": "https://tube.funfacts.de/api/v1/videos/c8935468-d4e2-4d0e-9553-861339374554/metadata/108330"
+    }
+  ]
+}
+"""
     
 }

--- a/Tests/VernissageServerTests/ServicesTests/ActivityPubIncomingServiceCreateTests.swift
+++ b/Tests/VernissageServerTests/ServicesTests/ActivityPubIncomingServiceCreateTests.swift
@@ -396,4 +396,74 @@ struct ActivityPubIncomingServiceCreateTests {
             .all()
         application.clearFiles(attachments: attachments)
     }
+
+    @Test
+    func `Unsupported object type with image should not be created as status`() async throws {
+        // Arrange.
+        let activityPubIncomingService = ActivityPubIncomingService()
+        let queueContext = application.getQueueContext(queueName: QueueName(string: "ActivityPubUserInboxJob"))
+
+        let sourceUser = try await application.createUser(userName: "remoteunsupportedcreate", isLocal: false)
+        let recipientUser = try await application.createUser(userName: "unsupportedrecipient")
+        _ = try await application.createFollow(sourceId: recipientUser.requireID(), targetId: sourceUser.requireID(), approved: true)
+
+        let objectId = "https://remote.example/videos/unsupported-create-1"
+        let noteDto = NoteDto(id: objectId,
+                              type: "Video",
+                              summary: nil,
+                              inReplyTo: nil,
+                              published: Date().toISO8601String(),
+                              updated: nil,
+                              url: objectId,
+                              attributedTo: sourceUser.activityPubProfile,
+                              to: .single(ActorDto(id: "https://www.w3.org/ns/activitystreams#Public")),
+                              cc: nil,
+                              sensitive: false,
+                              atomUri: nil,
+                              inReplyToAtomUri: nil,
+                              conversation: nil,
+                              content: "Unsupported video object.",
+                              attachment: [
+                                MediaAttachmentDto(mediaType: "image/png",
+                                                   url: externalImageUrl,
+                                                   name: "Video preview",
+                                                   blurhash: nil,
+                                                   width: 1706,
+                                                   height: 882,
+                                                   hdrImageUrl: nil,
+                                                   exif: nil,
+                                                   exifData: nil,
+                                                   location: nil)
+                              ],
+                              tag: nil)
+
+        let activity = ActivityDto(context: .single(ContextDto(value: "https://www.w3.org/ns/activitystreams")),
+                                   type: .create,
+                                   id: "\(objectId)/activity",
+                                   actor: .single(ActorDto(id: sourceUser.activityPubProfile)),
+                                   to: noteDto.to,
+                                   cc: noteDto.cc,
+                                   object: .single(ObjectDto(id: noteDto.id, type: .note, object: noteDto)),
+                                   summary: nil,
+                                   signature: nil,
+                                   published: noteDto.published)
+
+        let request = ActivityPubRequestDto(activity: activity,
+                                            headers: [:],
+                                            bodyHash: nil,
+                                            bodyValue: "{}",
+                                            httpMethod: .post,
+                                            httpPath: .userInbox(recipientUser.userName),
+                                            receivedAt: Date.now)
+
+        // Act.
+        try await activityPubIncomingService.create(activityPubRequest: request, on: queueContext.executionContext)
+
+        // Assert.
+        let status = try await Status.query(on: application.db)
+            .filter(\.$activityPubId == objectId)
+            .first()
+
+        #expect(status == nil, "Unsupported ActivityStreams object should not be created even when it has an image attachment.")
+    }
 }


### PR DESCRIPTION
When we retrieve a "Create" object with the "Video" type, we need to deserialize the object properly and then skip it as unsupported.