### PR TITLE
#570 Improve reschedulers (schedule create)

### DIFF
--- a/Sources/VernissageServer/Application+Schedulers.swift
+++ b/Sources/VernissageServer/Application+Schedulers.swift
@@ -32,8 +32,25 @@ extension Application {
         
         self.queues.schedule(RescheduleActivityPubJob()).hourly().at(15)
         self.queues.schedule(RescheduleActivityPubJob()).hourly().at(45)
-        self.queues.schedule(RescheduleAccountMigrationActivityPubJob()).every(minutes: 5)
-        self.queues.schedule(EmailSchedulerJob()).every(minutes: 5)
+        self.queues.schedule(RecoverMissingStatusActivityPubEventsJob()).hourly().at(5)
+
+        self.queues.schedule(RescheduleAccountMigrationActivityPubJob()).hourly().at(0)
+        self.queues.schedule(RescheduleAccountMigrationActivityPubJob()).hourly().at(15)
+        self.queues.schedule(RescheduleAccountMigrationActivityPubJob()).hourly().at(30)
+        self.queues.schedule(RescheduleAccountMigrationActivityPubJob()).hourly().at(45)
+
+        self.queues.schedule(EmailSchedulerJob()).hourly().at(0)
+        self.queues.schedule(EmailSchedulerJob()).hourly().at(5)
+        self.queues.schedule(EmailSchedulerJob()).hourly().at(10)
+        self.queues.schedule(EmailSchedulerJob()).hourly().at(15)
+        self.queues.schedule(EmailSchedulerJob()).hourly().at(20)
+        self.queues.schedule(EmailSchedulerJob()).hourly().at(25)
+        self.queues.schedule(EmailSchedulerJob()).hourly().at(30)
+        self.queues.schedule(EmailSchedulerJob()).hourly().at(35)
+        self.queues.schedule(EmailSchedulerJob()).hourly().at(40)
+        self.queues.schedule(EmailSchedulerJob()).hourly().at(45)
+        self.queues.schedule(EmailSchedulerJob()).hourly().at(50)
+        self.queues.schedule(EmailSchedulerJob()).hourly().at(55)
     }
 
     private func registerNightJobs() {

--- a/Sources/VernissageServer/Controllers/StatusesController.swift
+++ b/Sources/VernissageServer/Controllers/StatusesController.swift
@@ -522,7 +522,7 @@ struct StatusesController {
         if isSilent == false, let statusId = statusFromDatabase.id {
             try await request
                 .queues(.statusSender)
-                .dispatch(StatusCreaterJob.self, statusId, maxRetryCount: 2)
+                .dispatch(StatusCreaterJob.self, statusId, maxRetryCount: 3)
         }
         
         // Prepare and return status.
@@ -884,7 +884,7 @@ struct StatusesController {
         if let statusId = statusFromDatabase.id {
             try await request
                 .queues(.statusUpdater)
-                .dispatch(StatusUpdaterJob.self, statusId, maxRetryCount: 2)
+                .dispatch(StatusUpdaterJob.self, statusId, maxRetryCount: 3)
         }
         
         // Prepare and return status.
@@ -951,7 +951,7 @@ struct StatusesController {
             
             try await request
                 .queues(.statusDeleter)
-                .dispatch(StatusDeleterJob.self, statusDeleteJobDto, maxRetryCount: 2)
+                .dispatch(StatusDeleterJob.self, statusDeleteJobDto, maxRetryCount: 3)
         }
 
         return HTTPStatus.ok
@@ -1003,7 +1003,7 @@ struct StatusesController {
             let statusDeleterJobDto = try StatusDeleteJobDto(userId: status.user.requireID(), statusId: statusId, activityPubStatusId: status.activityPubId)
             try await request
                 .queues(.statusDeleter)
-                .dispatch(StatusDeleterJob.self, statusDeleterJobDto, maxRetryCount: 2)
+                .dispatch(StatusDeleterJob.self, statusDeleterJobDto, maxRetryCount: 3)
         }
         
         return HTTPStatus.ok
@@ -1469,7 +1469,7 @@ struct StatusesController {
         
         try await request
             .queues(.statusReblogger)
-            .dispatch(StatusRebloggerJob.self, status.requireID(), maxRetryCount: 2)
+            .dispatch(StatusRebloggerJob.self, status.requireID(), maxRetryCount: 3)
         
         // Prepare and return status.
         let statusFromDatabaseAfterReblog = try await statusesService.get(id: statusId, on: request.db)
@@ -1625,7 +1625,7 @@ struct StatusesController {
         
         try await request
             .queues(.statusUnreblogger)
-            .dispatch(StatusUnrebloggerJob.self, activityPubUnreblogDto, maxRetryCount: 2)
+            .dispatch(StatusUnrebloggerJob.self, activityPubUnreblogDto, maxRetryCount: 3)
         
         // Prepare and return status.
         let statusFromDatabaseAfterUnreblog = try await statusesService.get(id: mainStatusId, on: request.db)
@@ -1847,7 +1847,7 @@ struct StatusesController {
             if statusFromDatabaseBeforeFavourite.isLocal == false {
                 try await request
                     .queues(.statusFavouriter)
-                    .dispatch(StatusFavouriterJob.self, statusFavourite.requireID(), maxRetryCount: 2)
+                    .dispatch(StatusFavouriterJob.self, statusFavourite.requireID(), maxRetryCount: 3)
             }
         }
         
@@ -1974,7 +1974,7 @@ struct StatusesController {
 
                 try await request
                     .queues(.statusUnfavouriter)
-                    .dispatch(StatusUnfavouriterJob.self, statusUnfavoriteJobDto, maxRetryCount: 2)
+                    .dispatch(StatusUnfavouriterJob.self, statusUnfavoriteJobDto, maxRetryCount: 3)
             }
         }
         
@@ -2413,7 +2413,7 @@ struct StatusesController {
         if status.isLocal {
             try await request
                 .queues(.statusPinner)
-                .dispatch(StatusPinnerJob.self, statusId, maxRetryCount: 2)
+                .dispatch(StatusPinnerJob.self, statusId, maxRetryCount: 3)
         }
 
         guard let statusFromDatabaseAfterPin = try await statusesService.get(id: statusId, on: request.db) else {
@@ -2467,7 +2467,7 @@ struct StatusesController {
         if status.isLocal {
             try await request
                 .queues(.statusUnpinner)
-                .dispatch(StatusUnpinnerJob.self, statusId, maxRetryCount: 2)
+                .dispatch(StatusUnpinnerJob.self, statusId, maxRetryCount: 3)
         }
 
         guard let statusFromDatabaseAfterUnpin = try await statusesService.get(id: statusId, on: request.db) else {

--- a/Sources/VernissageServer/Controllers/UsersController.swift
+++ b/Sources/VernissageServer/Controllers/UsersController.swift
@@ -772,7 +772,7 @@ struct UsersController {
         } else {
             try await request
                 .queues(.userDeleter)
-                .dispatch(UserDeleterJob.self, userFromDb.requireID(), maxRetryCount: 2)
+                .dispatch(UserDeleterJob.self, userFromDb.requireID(), maxRetryCount: 3)
         }
 
         return HTTPStatus.ok

--- a/Sources/VernissageServer/Extensions/AsyncScheduledJob+Single.swift
+++ b/Sources/VernissageServer/Extensions/AsyncScheduledJob+Single.swift
@@ -8,30 +8,30 @@ import Foundation
 import Queues
 
 public extension AsyncScheduledJob {
-    func single(jobId: String, on context: QueueContext) async throws -> Bool {
+    func single(jobId: String, lockFor seconds: Int, on context: QueueContext) async throws -> Bool {
         // Queues and Redis are using same configuration, when Queue are not configured then Redis also is not configured.
-        if let _ = context.application.queues.driver as? EchoQueuesDriver {
+        if context.application.queues.driver is EchoQueuesDriver {
             return true
         }
-        
-        // Sending token to redis memory.
-        let trendingJobGuid = String.createRandomString(length: 10)
-        _ = try await context.application.redis.set(key: jobId, value: trendingJobGuid)
-        
-        // Waiting for registering all jobs.
-        sleep(5)
-        
-        // Checking if job can continue working.
-        let value = try await context.application.redis.get(key: jobId)
-        let workingJobGuid = value.string
-        
-        // When different token is stored in the Redis then different worker will run.
-        guard workingJobGuid == trendingJobGuid else {
-            context.logger.info("Different background job instance will run job (current id: \(trendingJobGuid), working id: \(workingJobGuid ?? "").")
+
+        let workerId = UUID().uuidString
+        let response = try await context.application.redis.send(
+            command: "SET",
+            with: [
+                .init(from: "scheduled-job:\(jobId)"),
+                .init(from: workerId),
+                .init(from: "NX"),
+                .init(from: "EX"),
+                .init(from: seconds)
+            ]
+        )
+
+        guard response.isNull == false else {
+            context.logger.info("[\(jobId)] Another instance claimed this execution.")
             return false
         }
-        
-        context.logger.info("Worker with id: \(trendingJobGuid) is working.")
+
+        context.logger.info("[\(jobId)] Execution claimed by worker '\(workerId)'.")
         return true
     }
 }

--- a/Sources/VernissageServer/QueueJobs/ActivityPubFollowRequesterJob.swift
+++ b/Sources/VernissageServer/QueueJobs/ActivityPubFollowRequesterJob.swift
@@ -45,7 +45,7 @@ import ActivityPubKit
  For follow request after sending request we have to expected that we will got `Accept` or `Reject` activity. Activity will be send
  automatically when user disabled manual approval or we have to wait for manual approval.
 */
-struct ActivityPubFollowRequesterJob: AsyncJob {
+struct ActivityPubFollowRequesterJob: RetryableAsyncJob {
     typealias Payload = ActivityPubFollowRequestDto
 
     func dequeue(_ context: QueueContext, _ payload: ActivityPubFollowRequestDto) async throws {

--- a/Sources/VernissageServer/QueueJobs/ActivityPubFollowResponderJob.swift
+++ b/Sources/VernissageServer/QueueJobs/ActivityPubFollowResponderJob.swift
@@ -48,7 +48,7 @@ import ActivityPubKit
  ```
  After sending `Accept` request remote instance should start sending information from following account.
 */
-struct ActivityPubFollowResponderJob: AsyncJob {
+struct ActivityPubFollowResponderJob: RetryableAsyncJob {
     typealias Payload = ActivityPubFollowRespondDto
 
     func dequeue(_ context: QueueContext, _ payload: ActivityPubFollowRespondDto) async throws {

--- a/Sources/VernissageServer/QueueJobs/ActivityPubMigrationFollowRequesterJob.swift
+++ b/Sources/VernissageServer/QueueJobs/ActivityPubMigrationFollowRequesterJob.swift
@@ -8,7 +8,7 @@ import Queues
 import Vapor
 
 /// Background job responsible for sending a persistent migration Follow or Undo Follow item.
-struct ActivityPubMigrationFollowRequesterJob: AsyncJob {
+struct ActivityPubMigrationFollowRequesterJob: RetryableAsyncJob {
     typealias Payload = MigrationActivityPubEventItemJobDto
 
     func dequeue(_ context: QueueContext, _ payload: MigrationActivityPubEventItemJobDto) async throws {

--- a/Sources/VernissageServer/QueueJobs/ActivityPubMoveRequesterJob.swift
+++ b/Sources/VernissageServer/QueueJobs/ActivityPubMoveRequesterJob.swift
@@ -8,7 +8,7 @@ import Vapor
 import Queues
 
 /// Background job responsible for sending account migration requests to remote instances.
-struct ActivityPubMoveRequesterJob: AsyncJob {
+struct ActivityPubMoveRequesterJob: RetryableAsyncJob {
     typealias Payload = MigrationActivityPubEventItemJobDto
 
     func dequeue(_ context: QueueContext, _ payload: MigrationActivityPubEventItemJobDto) async throws {

--- a/Sources/VernissageServer/QueueJobs/ActivityPubProfileUpdateJob.swift
+++ b/Sources/VernissageServer/QueueJobs/ActivityPubProfileUpdateJob.swift
@@ -8,7 +8,7 @@ import Vapor
 import Queues
 
 /// Background job for sending user profile updates to remote mutual follows.
-struct ActivityPubProfileUpdateJob: AsyncJob {
+struct ActivityPubProfileUpdateJob: RetryableAsyncJob {
     typealias Payload = ActivityPubProfileUpdateJobDto
 
     func dequeue(_ context: QueueContext, _ payload: ActivityPubProfileUpdateJobDto) async throws {

--- a/Sources/VernissageServer/QueueJobs/ActivityPubSharedInboxJob.swift
+++ b/Sources/VernissageServer/QueueJobs/ActivityPubSharedInboxJob.swift
@@ -10,7 +10,7 @@ import Queues
 import ActivityPubKit
 
 /// Bakcground job resposible for consumig all request done to Activity Pub shared inbox.
-struct ActivityPubSharedInboxJob: AsyncJob {
+struct ActivityPubSharedInboxJob: RetryableAsyncJob {
     typealias Payload = ActivityPubRequestDto
 
     func dequeue(_ context: QueueContext, _ payload: ActivityPubRequestDto) async throws {

--- a/Sources/VernissageServer/QueueJobs/ActivityPubStatusJob.swift
+++ b/Sources/VernissageServer/QueueJobs/ActivityPubStatusJob.swift
@@ -10,7 +10,7 @@ import FluentSQL
 import Queues
 
 /// Background job for sending status events to remote server.
-struct ActivityPubStatusJob: AsyncJob {
+struct ActivityPubStatusJob: RetryableAsyncJob {
     typealias Payload = ActivityPubStatusJobDataDto
 
     func dequeue(_ context: QueueContext, _ payload: ActivityPubStatusJobDataDto) async throws {

--- a/Sources/VernissageServer/QueueJobs/ActivityPubUserInboxJob.swift
+++ b/Sources/VernissageServer/QueueJobs/ActivityPubUserInboxJob.swift
@@ -10,7 +10,7 @@ import Queues
 import ActivityPubKit
 
 /// Bakcground job resposible for consumig all request done to Activity Pub user inbox.
-struct ActivityPubUserInboxJob: AsyncJob {
+struct ActivityPubUserInboxJob: RetryableAsyncJob {
     typealias Payload = ActivityPubRequestDto
 
     func dequeue(_ context: QueueContext, _ payload: ActivityPubRequestDto) async throws {

--- a/Sources/VernissageServer/QueueJobs/ActivityPubUserOutboxJob.swift
+++ b/Sources/VernissageServer/QueueJobs/ActivityPubUserOutboxJob.swift
@@ -10,7 +10,7 @@ import Queues
 import ActivityPubKit
 
 /// Bakcground job resposible for consumig all request done to Activity Pub user outbox.
-struct ActivityPubUserOutboxJob: AsyncJob {
+struct ActivityPubUserOutboxJob: RetryableAsyncJob {
     typealias Payload = ActivityPubRequestDto
 
     func dequeue(_ context: QueueContext, _ payload: ActivityPubRequestDto) async throws {

--- a/Sources/VernissageServer/QueueJobs/CollectionUpdaterJob.swift
+++ b/Sources/VernissageServer/QueueJobs/CollectionUpdaterJob.swift
@@ -8,7 +8,7 @@ import Vapor
 import Queues
 
 /// Background job for synchronizing remote user featured collection.
-struct CollectionUpdaterJob: AsyncJob {
+struct CollectionUpdaterJob: RetryableAsyncJob {
     typealias Payload = Int64
 
     func dequeue(_ context: QueueContext, _ payload: Int64) async throws {

--- a/Sources/VernissageServer/QueueJobs/EmailJob.swift
+++ b/Sources/VernissageServer/QueueJobs/EmailJob.swift
@@ -10,7 +10,7 @@ import Queues
 import Smtp
 
 /// Background job for sending email.
-struct EmailJob: AsyncJob {
+struct EmailJob: RetryableAsyncJob {
     typealias Payload = EmailJobDto
 
     func dequeue(_ context: QueueContext, _ payload: EmailJobDto) async throws {

--- a/Sources/VernissageServer/QueueJobs/EmailSenderJob.swift
+++ b/Sources/VernissageServer/QueueJobs/EmailSenderJob.swift
@@ -8,7 +8,7 @@ import Queues
 import Vapor
 
 /// Background job that claims a persistent email delivery and hands it to the SMTP job.
-struct EmailSenderJob: AsyncJob {
+struct EmailSenderJob: RetryableAsyncJob {
     typealias Payload = EmailSenderJobDto
 
     func dequeue(_ context: QueueContext, _ payload: EmailSenderJobDto) async throws {

--- a/Sources/VernissageServer/QueueJobs/FlagCreaterJob.swift
+++ b/Sources/VernissageServer/QueueJobs/FlagCreaterJob.swift
@@ -8,7 +8,7 @@ import Vapor
 import Queues
 
 /// Background job responsible for forwarding local reports as ActivityPub Flag activities.
-struct FlagCreaterJob: AsyncJob {
+struct FlagCreaterJob: RetryableAsyncJob {
     typealias Payload = Int64
 
     func dequeue(_ context: QueueContext, _ payload: Int64) async throws {

--- a/Sources/VernissageServer/QueueJobs/FollowingImporterJob.swift
+++ b/Sources/VernissageServer/QueueJobs/FollowingImporterJob.swift
@@ -10,7 +10,7 @@ import Queues
 import Smtp
 
 /// Background job for importing follwing accounts.
-struct FollowingImporterJob: AsyncJob {
+struct FollowingImporterJob: RetryableAsyncJob {
     typealias Payload = Int64
 
     func dequeue(_ context: QueueContext, _ payload: Int64) async throws {

--- a/Sources/VernissageServer/QueueJobs/RetryableAsyncJob.swift
+++ b/Sources/VernissageServer/QueueJobs/RetryableAsyncJob.swift
@@ -1,0 +1,24 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Queues
+
+protocol RetryableAsyncJob: AsyncJob { }
+
+extension RetryableAsyncJob {
+    func nextRetryIn(attempt: Int) -> Int {
+        switch attempt {
+        case 1:
+            return 1 * 60
+        case 2:
+            return 5 * 60
+        case 3:
+            return 15 * 60
+        default:
+            return 0
+        }
+    }
+}

--- a/Sources/VernissageServer/QueueJobs/StatusCreaterJob.swift
+++ b/Sources/VernissageServer/QueueJobs/StatusCreaterJob.swift
@@ -10,7 +10,7 @@ import Queues
 import Smtp
 
 /// Background job for sending status to remote server.
-struct StatusCreaterJob: AsyncJob {
+struct StatusCreaterJob: RetryableAsyncJob {
     typealias Payload = Int64
 
     func dequeue(_ context: QueueContext, _ payload: Int64) async throws {

--- a/Sources/VernissageServer/QueueJobs/StatusDeleterJob.swift
+++ b/Sources/VernissageServer/QueueJobs/StatusDeleterJob.swift
@@ -10,7 +10,7 @@ import Queues
 import Smtp
 
 /// Background job for delete status.
-struct StatusDeleterJob: AsyncJob {
+struct StatusDeleterJob: RetryableAsyncJob {
     typealias Payload = StatusDeleteJobDto
 
     func dequeue(_ context: QueueContext, _ payload: StatusDeleteJobDto) async throws {

--- a/Sources/VernissageServer/QueueJobs/StatusFavouriterJob.swift
+++ b/Sources/VernissageServer/QueueJobs/StatusFavouriterJob.swift
@@ -10,7 +10,7 @@ import Queues
 import Smtp
 
 /// Background job for favourite status.
-struct StatusFavouriterJob: AsyncJob {
+struct StatusFavouriterJob: RetryableAsyncJob {
     typealias Payload = Int64
 
     func dequeue(_ context: QueueContext, _ payload: Int64) async throws {

--- a/Sources/VernissageServer/QueueJobs/StatusPinnerJob.swift
+++ b/Sources/VernissageServer/QueueJobs/StatusPinnerJob.swift
@@ -8,7 +8,7 @@ import Vapor
 import Queues
 
 /// Background job for sending `Add` to remote featured collections.
-struct StatusPinnerJob: AsyncJob {
+struct StatusPinnerJob: RetryableAsyncJob {
     typealias Payload = Int64
 
     func dequeue(_ context: QueueContext, _ payload: Int64) async throws {

--- a/Sources/VernissageServer/QueueJobs/StatusRebloggerJob.swift
+++ b/Sources/VernissageServer/QueueJobs/StatusRebloggerJob.swift
@@ -10,7 +10,7 @@ import Queues
 import Smtp
 
 /// Background job for reblog status.
-struct StatusRebloggerJob: AsyncJob {
+struct StatusRebloggerJob: RetryableAsyncJob {
     typealias Payload = Int64
 
     func dequeue(_ context: QueueContext, _ payload: Int64) async throws {

--- a/Sources/VernissageServer/QueueJobs/StatusUnfavouriterJob.swift
+++ b/Sources/VernissageServer/QueueJobs/StatusUnfavouriterJob.swift
@@ -10,7 +10,7 @@ import Queues
 import Smtp
 
 /// Background job for unfavourite status.
-struct StatusUnfavouriterJob: AsyncJob {
+struct StatusUnfavouriterJob: RetryableAsyncJob {
     typealias Payload = StatusUnfavouriteJobDto
 
     func dequeue(_ context: QueueContext, _ payload: StatusUnfavouriteJobDto) async throws {

--- a/Sources/VernissageServer/QueueJobs/StatusUnpinnerJob.swift
+++ b/Sources/VernissageServer/QueueJobs/StatusUnpinnerJob.swift
@@ -8,7 +8,7 @@ import Vapor
 import Queues
 
 /// Background job for sending `Remove` to remote featured collections.
-struct StatusUnpinnerJob: AsyncJob {
+struct StatusUnpinnerJob: RetryableAsyncJob {
     typealias Payload = Int64
 
     func dequeue(_ context: QueueContext, _ payload: Int64) async throws {

--- a/Sources/VernissageServer/QueueJobs/StatusUnrebloggerJob.swift
+++ b/Sources/VernissageServer/QueueJobs/StatusUnrebloggerJob.swift
@@ -10,7 +10,7 @@ import Queues
 import Smtp
 
 /// Background job for unreblog status.
-struct StatusUnrebloggerJob: AsyncJob {
+struct StatusUnrebloggerJob: RetryableAsyncJob {
     typealias Payload = ActivityPubUnreblogDto
 
     func dequeue(_ context: QueueContext, _ payload: ActivityPubUnreblogDto) async throws {

--- a/Sources/VernissageServer/QueueJobs/StatusUpdaterJob.swift
+++ b/Sources/VernissageServer/QueueJobs/StatusUpdaterJob.swift
@@ -10,7 +10,7 @@ import Queues
 import Smtp
 
 /// Background job for sending updated status to remote server.
-struct StatusUpdaterJob: AsyncJob {
+struct StatusUpdaterJob: RetryableAsyncJob {
     typealias Payload = Int64
 
     func dequeue(_ context: QueueContext, _ payload: Int64) async throws {

--- a/Sources/VernissageServer/QueueJobs/UrlValidatorJob.swift
+++ b/Sources/VernissageServer/QueueJobs/UrlValidatorJob.swift
@@ -13,7 +13,7 @@ import RegexBuilder
 import SwiftSoup
 
 /// Background job for user's fields validation.
-struct UrlValidatorJob: AsyncJob {
+struct UrlValidatorJob: RetryableAsyncJob {
     typealias Payload = FlexiField
     
     func dequeue(_ context: QueueContext, _ payload: FlexiField) async throws {

--- a/Sources/VernissageServer/QueueJobs/UserDeleterJob.swift
+++ b/Sources/VernissageServer/QueueJobs/UserDeleterJob.swift
@@ -11,7 +11,7 @@ import Queues
 import Smtp
 
 /// Background job for user delete process.
-struct UserDeleterJob: AsyncJob {
+struct UserDeleterJob: RetryableAsyncJob {
     typealias Payload = Int64
 
     func dequeue(_ context: QueueContext, _ payload: Int64) async throws {

--- a/Sources/VernissageServer/QueueJobs/WebPushSenderJob.swift
+++ b/Sources/VernissageServer/QueueJobs/WebPushSenderJob.swift
@@ -10,7 +10,7 @@ import Queues
 import Smtp
 
 /// Background job for sending WebPush notifications.
-struct WebPushSenderJob: AsyncJob {
+struct WebPushSenderJob: RetryableAsyncJob {
     typealias Payload = WebPush
 
     func dequeue(_ context: QueueContext, _ payload: WebPush) async throws {

--- a/Sources/VernissageServer/ScheduledJobs/ClearAttachmentsJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/ClearAttachmentsJob.swift
@@ -22,7 +22,7 @@ struct ClearAttachmentsJob: AsyncScheduledJob {
         context.logger.info("[ClearAttachmentsJob] Job is running.")
                 
         // Check if current job can perform the work.
-        guard try await self.single(jobId: self.jobId, on: context) else {
+        guard try await self.single(jobId: self.jobId, lockFor: 55 * 60, on: context) else {
             return
         }
         

--- a/Sources/VernissageServer/ScheduledJobs/ClearDeletedUsersJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/ClearDeletedUsersJob.swift
@@ -22,7 +22,7 @@ struct ClearDeletedUsersJob: AsyncScheduledJob {
         context.logger.info("[ClearDeletedUsersJob] Job is running.")
                 
         // Check if current job can perform the work.
-        guard try await self.single(jobId: self.jobId, on: context) else {
+        guard try await self.single(jobId: self.jobId, lockFor: 23 * 60 * 60, on: context) else {
             return
         }
         

--- a/Sources/VernissageServer/ScheduledJobs/ClearErrorItemsJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/ClearErrorItemsJob.swift
@@ -26,7 +26,7 @@ struct ClearErrorItemsJob: AsyncScheduledJob {
         context.logger.info("[ClearErrorItemsJob] Job is running.")
         
         // Check if current job can perform the work.
-        guard try await self.single(jobId: self.jobId, on: context) else {
+        guard try await self.single(jobId: self.jobId, lockFor: 23 * 60 * 60, on: context) else {
             return
         }
 

--- a/Sources/VernissageServer/ScheduledJobs/ClearFailedLoginsJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/ClearFailedLoginsJob.swift
@@ -26,7 +26,7 @@ struct ClearFailedLoginsJob: AsyncScheduledJob {
         context.logger.info("[ClearFailedLoginsJob] Job is running.")
 
         // Check if current job can perform the work.
-        guard try await self.single(jobId: self.jobId, on: context) else {
+        guard try await self.single(jobId: self.jobId, lockFor: 23 * 60 * 60, on: context) else {
             return
         }
 

--- a/Sources/VernissageServer/ScheduledJobs/ClearQuickCaptchasJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/ClearQuickCaptchasJob.swift
@@ -26,7 +26,7 @@ struct ClearQuickCaptchasJob: AsyncScheduledJob {
         context.logger.info("[ClearQuickCaptchasJob] Job is running.")
 
         // Check if current job can perform the work.
-        guard try await self.single(jobId: self.jobId, on: context) else {
+        guard try await self.single(jobId: self.jobId, lockFor: 55 * 60, on: context) else {
             return
         }
 

--- a/Sources/VernissageServer/ScheduledJobs/CreateArchiveJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/CreateArchiveJob.swift
@@ -26,7 +26,7 @@ struct CreateArchiveJob: AsyncScheduledJob {
         context.logger.info("[CreateArchiveJob] Job is running.")
 
         // Check if current job can perform the work.
-        guard try await self.single(jobId: self.jobId, on: context) else {
+        guard try await self.single(jobId: self.jobId, lockFor: 23 * 60 * 60, on: context) else {
             return
         }
 

--- a/Sources/VernissageServer/ScheduledJobs/DeleteArchiveJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/DeleteArchiveJob.swift
@@ -26,7 +26,7 @@ struct DeleteArchiveJob: AsyncScheduledJob {
         context.logger.info("[DeleteArchiveJob] Job is running.")
 
         // Check if current job can perform the work.
-        guard try await self.single(jobId: self.jobId, on: context) else {
+        guard try await self.single(jobId: self.jobId, lockFor: 23 * 60 * 60, on: context) else {
             return
         }
 

--- a/Sources/VernissageServer/ScheduledJobs/EmailSchedulerJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/EmailSchedulerJob.swift
@@ -9,8 +9,15 @@ import Vapor
 
 /// Re-enqueues email deliveries that are waiting, ready for retry or left processing after a worker failure.
 struct EmailSchedulerJob: AsyncScheduledJob {
+    private let jobId = "EmailSchedulerJob"
+
     func run(context: QueueContext) async throws {
         context.logger.info("[EmailSchedulerJob] Job is running.")
+
+        guard try await self.single(jobId: self.jobId, lockFor: 4 * 60, on: context) else {
+            return
+        }
+
         try await context.application.services.emailDeliveryService.dispatchPending(on: context.executionContext)
         context.logger.info("[EmailSchedulerJob] Job finished.")
     }

--- a/Sources/VernissageServer/ScheduledJobs/LocationsJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/LocationsJob.swift
@@ -23,7 +23,7 @@ struct LocationsJob: AsyncScheduledJob {
         context.logger.info("[LocationsJob] Job is running.")
 
         // Check if current job can perform the work.
-        guard try await self.single(jobId: self.jobId, on: context) else {
+        guard try await self.single(jobId: self.jobId, lockFor: 23 * 60 * 60, on: context) else {
             return
         }
 

--- a/Sources/VernissageServer/ScheduledJobs/LongPeriodTrendingJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/LongPeriodTrendingJob.swift
@@ -26,7 +26,7 @@ struct LongPeriodTrendingJob: AsyncScheduledJob {
         context.logger.info("[LongPeriodTrendingJob] Job is running.")
 
         // Check if current job can perform the work.
-        guard try await self.single(jobId: self.jobId, on: context) else {
+        guard try await self.single(jobId: self.jobId, lockFor: 23 * 60 * 60, on: context) else {
             return
         }
 

--- a/Sources/VernissageServer/ScheduledJobs/PurgeStatusesJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/PurgeStatusesJob.swift
@@ -26,7 +26,7 @@ struct PurgeStatusesJob: AsyncScheduledJob {
         context.logger.info("[PurgeStatusesJob] Job is running.")
 
         // Check if current job can perform the work.
-        guard try await self.single(jobId: self.jobId, on: context) else {
+        guard try await self.single(jobId: self.jobId, lockFor: 14 * 60, on: context) else {
             return
         }
 

--- a/Sources/VernissageServer/ScheduledJobs/RecoverMissingStatusActivityPubEventsJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/RecoverMissingStatusActivityPubEventsJob.swift
@@ -1,0 +1,68 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2026 Marcin Czachurski and the repository contributors.
+//  Licensed under the Apache License 2.0.
+//
+
+import Fluent
+import Foundation
+import Queues
+import Smtp
+import Vapor
+
+/// Re-enqueues local statuses for which the ActivityPub Create event was not created.
+struct RecoverMissingStatusActivityPubEventsJob: AsyncScheduledJob {
+    private static let batchSize = 100
+    private let jobId = "RecoverMissingStatusActivityPubEventsJob"
+
+    func run(context: QueueContext) async throws {
+        guard context.application.settings.cached?.rescheduleActivityPubJobEnabled != false else {
+            context.logger.info("[RecoverMissingStatusActivityPubEventsJob] Job is disabled in settings.")
+            return
+        }
+
+        context.logger.info("[RecoverMissingStatusActivityPubEventsJob] Job is running.")
+
+        guard try await self.single(jobId: self.jobId, lockFor: 55 * 60, on: context) else {
+            return
+        }
+
+        let thirtyMinutesAgo = Date.now.addingTimeInterval(-30 * 60)
+        let statuses = try await Status.query(on: context.application.db)
+            .filter(\.$isLocal == true)
+            .filter(\.$visibility ~~ [.public, .followers])
+            .filter(\.$reblog.$id == nil)
+            .filter(\.$createdAt > Date.weekAgo)
+            .filter(\.$createdAt < thirtyMinutesAgo)
+            .join(
+                StatusActivityPubEvent.self,
+                on: \Status.$id == \StatusActivityPubEvent.$status.$id
+                    && \StatusActivityPubEvent.$type == StatusActivityPubEventType.create,
+                method: .left
+            )
+            .filter(StatusActivityPubEvent.self, \.$createdAt == nil)
+            .field(\.$id)
+            .sort(\.$createdAt, .ascending)
+            .limit(Self.batchSize)
+            .all()
+
+        let statusIds = statuses.compactMap(\.id)
+        context.logger.info("[RecoverMissingStatusActivityPubEventsJob] Job found \(statusIds.count) statuses to recover.")
+
+        for statusId in statusIds {
+            do {
+                try await context
+                    .queues(.statusSender)
+                    .dispatch(StatusCreaterJob.self, statusId, maxRetryCount: 3)
+            } catch {
+                await context.logger.store(
+                    "[RecoverMissingStatusActivityPubEventsJob] Cannot enqueue status '\(statusId)'.",
+                    error,
+                    on: context.application
+                )
+            }
+        }
+
+        context.logger.info("[RecoverMissingStatusActivityPubEventsJob] Job finished processing.")
+    }
+}

--- a/Sources/VernissageServer/ScheduledJobs/RescheduleAccountMigrationActivityPubJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/RescheduleAccountMigrationActivityPubJob.swift
@@ -9,6 +9,8 @@ import Vapor
 
 /// Re-enqueues migration deliveries that are waiting, ready for retry or left processing after a worker failure.
 struct RescheduleAccountMigrationActivityPubJob: AsyncScheduledJob {
+    private let jobId = "RescheduleAccountMigrationActivityPubJob"
+
     func run(context: QueueContext) async throws {
         guard context.application.settings.cached?.rescheduleActivityPubJobEnabled != false else {
             context.logger.info("[RescheduleAccountMigrationActivityPubJob] Job is disabled in settings.")
@@ -16,6 +18,11 @@ struct RescheduleAccountMigrationActivityPubJob: AsyncScheduledJob {
         }
 
         context.logger.info("[RescheduleAccountMigrationActivityPubJob] Job is running.")
+
+        guard try await self.single(jobId: self.jobId, lockFor: 14 * 60, on: context) else {
+            return
+        }
+
         try await context.application.services.accountMigrationActivityPubService.dispatchPending(on: context.executionContext)
         context.logger.info("[RescheduleAccountMigrationActivityPubJob] Job finished.")
     }

--- a/Sources/VernissageServer/ScheduledJobs/RescheduleActivityPubJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/RescheduleActivityPubJob.swift
@@ -26,7 +26,7 @@ struct RescheduleActivityPubJob: AsyncScheduledJob {
         context.logger.info("[RescheduleActivityPubJob] Job is running.")
 
         // Check if current job can perform the work.
-        guard try await self.single(jobId: self.jobId, on: context) else {
+        guard try await self.single(jobId: self.jobId, lockFor: 29 * 60, on: context) else {
             return
         }
 

--- a/Sources/VernissageServer/ScheduledJobs/ShortPeriodTrendingJob.swift
+++ b/Sources/VernissageServer/ScheduledJobs/ShortPeriodTrendingJob.swift
@@ -26,7 +26,7 @@ struct ShortPeriodTrendingJob: AsyncScheduledJob {
         context.logger.info("[ShortPeriodTrendingJob] Job is running.")
 
         // Check if current job can perform the work.
-        guard try await self.single(jobId: self.jobId, on: context) else {
+        guard try await self.single(jobId: self.jobId, lockFor: 55 * 60, on: context) else {
             return
         }
 

--- a/Sources/VernissageServer/Services/StatusesService.swift
+++ b/Sources/VernissageServer/Services/StatusesService.swift
@@ -807,13 +807,13 @@ final class StatusesService: StatusesServiceType {
                                                       on: context)
                 }
             } else {
-                // Create status on owner tineline.
-                let ownerUserStatusId = context.application.services.snowflakeService.generate()
-                let ownerUserStatus = try UserStatus(id: ownerUserStatusId, type: .owner, userId: status.user.requireID(), statusId: statusId)
-                try await ownerUserStatus.create(on: context.application.db)
+                let ownerUserId = try status.user.requireID()
+
+                // Create status on owner timeline if it does not exist yet.
+                try await self.createOnUserOwnerTimeline(ownerUserId: ownerUserId, statusId: statusId, on: context)
 
                 // Create statuses on local followers timeline.
-                try await self.createOnLocalTimeline(followersOf: status.user.requireID(), status: status, on: context)
+                try await self.createOnLocalTimeline(followersOf: ownerUserId, status: status, on: context)
                 try await self.createOnLocalTimelineForHashtagsFollowers(status: status, on: context)
 
                 // Create mention notifications.
@@ -902,6 +902,11 @@ final class StatusesService: StatusesServiceType {
             throw Abort(.notFound)
         }
 
+        // Skip outdated jobs when the status has already been unpinned.
+        guard status.pinnedAt != nil else {
+            return
+        }
+
         switch status.visibility {
         case .public, .quietPublic:
             try await self.scheduleCollectionSend(status: status, type: .pin, on: context)
@@ -913,6 +918,11 @@ final class StatusesService: StatusesServiceType {
     func send(unpin statusId: Int64, on context: ExecutionContext) async throws {
         guard let status = try await self.get(id: statusId, on: context.db) else {
             throw Abort(.notFound)
+        }
+
+        // Skip outdated jobs when the status has already been pinned again.
+        guard status.pinnedAt == nil else {
+            return
         }
 
         switch status.visibility {
@@ -3069,6 +3079,21 @@ final class StatusesService: StatusesServiceType {
 
         // We are retutning calculated category or category from database when we cannot calculate new category.
         return calculatedCategory ?? categoryFromDatabase
+    }
+
+    private func createOnUserOwnerTimeline(ownerUserId: Int64, statusId: Int64, on context: ExecutionContext) async throws {
+        let ownerStatusFromDatabase = try await UserStatus.query(on: context.application.db)
+            .filter(\.$user.$id == ownerUserId)
+            .filter(\.$status.$id == statusId)
+            .first()
+
+        guard ownerStatusFromDatabase == nil else {
+            return
+        }
+
+        let ownerUserStatusId = context.application.services.snowflakeService.generate()
+        let ownerUserStatus = UserStatus(id: ownerUserStatusId, type: .owner, userId: ownerUserId, statusId: statusId)
+        try await ownerUserStatus.create(on: context.application.db)
     }
 
     private func getCategory(basedOn hashtags: [String], on database: Database) async throws -> Category? {

--- a/Sources/VernissageServer/Services/UsersService.swift
+++ b/Sources/VernissageServer/Services/UsersService.swift
@@ -833,7 +833,7 @@ final class UsersService: UsersServiceType {
             do {
                 try await context
                     .queues(.collectionUpdater)
-                    .dispatch(CollectionUpdaterJob.self, user.requireID(), maxRetryCount: 2)
+                    .dispatch(CollectionUpdaterJob.self, user.requireID(), maxRetryCount: 3)
             } catch {
                 context.logger.warning("Cannot dispatch featured collection synchronization for user '\(user.activityPubProfile)'. Error: \(error).")
             }


### PR DESCRIPTION
This change improves recovery when a local status is created but its ActivityPub `Create` event is not persisted, for example when the application is terminated while processing `StatusCreaterJob`.

- Added delayed retries after 1, 5, and 15 minutes for selected asynchronous jobs.
- Added an hourly recovery job that re-enqueues statuses created between 30 minutes and one week ago without an ActivityPub `Create` event.
- Made owner timeline insertion idempotent for repeated status processing.
- Replaced the scheduled-job election mechanism with an atomic Redis `SET NX EX` claim.
- Aligned scheduled jobs to fixed clock times to prevent duplicate execution across application instances.
- Added guards that ignore stale pin and unpin jobs.